### PR TITLE
feat/136 add new measure (profile)

### DIFF
--- a/koswat/configuration/settings/koswat_general_settings.py
+++ b/koswat/configuration/settings/koswat_general_settings.py
@@ -16,9 +16,9 @@ class InfraCostsEnum(enum.Enum):
 
 
 class ConstructionTypeEnum(enum.Enum):
-    VZG = 1
-    CB_DAMWAND = 2
-    DAMWAND_ONVERANKERD = 3
-    DAMWAND_VERANKERD = 4
-    DIEPWAND = 5
-    KISTDAM = 6
+    VZG = 0
+    CB_DAMWAND = 1
+    DAMWAND_ONVERANKERD = 2
+    DAMWAND_VERANKERD = 3
+    DIEPWAND = 4
+    KISTDAM = 5

--- a/koswat/configuration/settings/koswat_general_settings.py
+++ b/koswat/configuration/settings/koswat_general_settings.py
@@ -16,8 +16,9 @@ class InfraCostsEnum(enum.Enum):
 
 
 class ConstructionTypeEnum(enum.Enum):
-    CB_DAMWAND = 0
-    DAMWAND_ONVERANKERD = 1
-    DAMWAND_VERANKERD = 2
-    DIEPWAND = 3
-    KISTDAM = 4
+    VZG = 1
+    CB_DAMWAND = 2
+    DAMWAND_ONVERANKERD = 3
+    DAMWAND_VERANKERD = 4
+    DIEPWAND = 5
+    KISTDAM = 6

--- a/koswat/configuration/settings/reinforcements/koswat_reinforcement_settings.py
+++ b/koswat/configuration/settings/reinforcements/koswat_reinforcement_settings.py
@@ -24,18 +24,16 @@ class KoswatReinforcementSettings(KoswatConfigProtocol):
     Wrapper of all settings per reinforcement.
     """
 
-    soil_settings: KoswatSoilSettings = field(
-        default_factory=lambda: KoswatSoilSettings()
-    )
-    vps_settings: KoswatVPSSettings = field(default_factory=lambda: KoswatVPSSettings())
+    soil_settings: KoswatSoilSettings = field(default_factory=KoswatSoilSettings)
+    vps_settings: KoswatVPSSettings = field(default_factory=KoswatVPSSettings)
     piping_wall_settings: KoswatPipingWallSettings = field(
-        default_factory=lambda: KoswatPipingWallSettings()
+        default_factory=KoswatPipingWallSettings
     )
     stability_wall_settings: KoswatStabilityWallSettings = field(
-        default_factory=lambda: KoswatStabilityWallSettings()
+        default_factory=KoswatStabilityWallSettings
     )
     cofferdam_settings: KoswatCofferdamSettings = field(
-        default_factory=lambda: KoswatCofferdamSettings()
+        default_factory=KoswatCofferdamSettings
     )
 
     def is_valid(self) -> bool:

--- a/koswat/configuration/settings/reinforcements/koswat_reinforcement_settings.py
+++ b/koswat/configuration/settings/reinforcements/koswat_reinforcement_settings.py
@@ -13,6 +13,9 @@ from koswat.configuration.settings.reinforcements.koswat_soil_settings import (
 from koswat.configuration.settings.reinforcements.koswat_stability_wall_settings import (
     KoswatStabilityWallSettings,
 )
+from koswat.configuration.settings.reinforcements.koswat_vps_settings import (
+    KoswatVPSSettings,
+)
 
 
 @dataclass
@@ -24,6 +27,7 @@ class KoswatReinforcementSettings(KoswatConfigProtocol):
     soil_settings: KoswatSoilSettings = field(
         default_factory=lambda: KoswatSoilSettings()
     )
+    vps_settings: KoswatVPSSettings = field(default_factory=lambda: KoswatVPSSettings())
     piping_wall_settings: KoswatPipingWallSettings = field(
         default_factory=lambda: KoswatPipingWallSettings()
     )

--- a/koswat/configuration/settings/reinforcements/koswat_vps_settings.py
+++ b/koswat/configuration/settings/reinforcements/koswat_vps_settings.py
@@ -1,0 +1,19 @@
+from dataclasses import dataclass
+
+from koswat.configuration.koswat_config_protocol import KoswatConfigProtocol
+from koswat.configuration.settings.koswat_general_settings import SurtaxFactorEnum
+
+
+@dataclass
+class KoswatVPSSettings(KoswatConfigProtocol):
+    """
+    Settings related to Vertical Piping Solution reinforcement
+    """
+
+    soil_surtax_factor: SurtaxFactorEnum = SurtaxFactorEnum.NORMAAL
+    constructive_surtax_factor: SurtaxFactorEnum = SurtaxFactorEnum.NORMAAL
+    land_purchase_surtax_factor: SurtaxFactorEnum = SurtaxFactorEnum.NORMAAL
+    binnen_berm_breedte_vps: float = 0
+
+    def is_valid(self) -> bool:
+        return True

--- a/koswat/dike_reinforcements/input_profile/__init__.py
+++ b/koswat/dike_reinforcements/input_profile/__init__.py
@@ -14,3 +14,7 @@ from koswat.dike_reinforcements.input_profile.stability_wall import (
     StabilityWallInputProfile,
     StabilityWallInputProfileCalculation,
 )
+from koswat.dike_reinforcements.input_profile.vertical_piping_solution import (
+    VPSInputProfile,
+    VPSInputProfileCalculation,
+)

--- a/koswat/dike_reinforcements/input_profile/vertical_piping_solution/__init__.py
+++ b/koswat/dike_reinforcements/input_profile/vertical_piping_solution/__init__.py
@@ -1,0 +1,6 @@
+from koswat.dike_reinforcements.input_profile.vertical_piping_solution.vps_input_profile import (
+    VPSInputProfile,
+)
+from koswat.dike_reinforcements.input_profile.vertical_piping_solution.vps_input_profile_calculation import (
+    VPSInputProfileCalculation,
+)

--- a/koswat/dike_reinforcements/input_profile/vertical_piping_solution/vps_input_profile.py
+++ b/koswat/dike_reinforcements/input_profile/vertical_piping_solution/vps_input_profile.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass
+
+from koswat.dike_reinforcements.input_profile.reinforcement_input_profile_protocol import (
+    ReinforcementInputProfileProtocol,
+)
+from koswat.dike_reinforcements.input_profile.soil.soil_input_profile import (
+    SoilInputProfile,
+)
+
+
+@dataclass
+class VPSInputProfile(SoilInputProfile, ReinforcementInputProfileProtocol):
+    @property
+    def reinforcement_domain_name(self) -> str:
+        return "Verticale piping oplossing"

--- a/koswat/dike_reinforcements/input_profile/vertical_piping_solution/vps_input_profile_calculation.py
+++ b/koswat/dike_reinforcements/input_profile/vertical_piping_solution/vps_input_profile_calculation.py
@@ -1,0 +1,69 @@
+from koswat.configuration.settings import KoswatScenario
+from koswat.configuration.settings.koswat_general_settings import ConstructionTypeEnum
+from koswat.configuration.settings.reinforcements.koswat_reinforcement_settings import (
+    KoswatReinforcementSettings,
+)
+from koswat.configuration.settings.reinforcements.koswat_vps_settings import (
+    KoswatVPSSettings,
+)
+from koswat.dike.koswat_profile_protocol import KoswatProfileProtocol
+from koswat.dike.profile.koswat_input_profile_base import KoswatInputProfileBase
+from koswat.dike_reinforcements.input_profile.reinforcement_input_profile_calculation_protocol import (
+    ReinforcementInputProfileCalculationProtocol,
+)
+from koswat.dike_reinforcements.input_profile.soil.soil_input_profile_calculation import (
+    SoilInputProfileCalculation,
+)
+from koswat.dike_reinforcements.input_profile.vertical_piping_solution.vps_input_profile import (
+    VPSInputProfile,
+)
+
+
+class VPSInputProfileCalculation(
+    SoilInputProfileCalculation,
+    ReinforcementInputProfileCalculationProtocol,
+):
+    base_profile: KoswatProfileProtocol
+    reinforcement_settings: KoswatReinforcementSettings
+    scenario: KoswatScenario
+
+    def __init__(self) -> None:
+        super().__init__()
+
+    def _calculate_new_input_profile(
+        self,
+        base_data: KoswatInputProfileBase,
+        vps_settings: KoswatVPSSettings,
+        scenario: KoswatScenario,
+    ) -> KoswatInputProfileBase:
+        _new_data = VPSInputProfile()
+        _new_data.dike_section = base_data.dike_section
+        _new_data.buiten_maaiveld = base_data.buiten_maaiveld
+        _new_data.buiten_talud = scenario.buiten_talud
+        _new_data.buiten_berm_hoogte = base_data.buiten_berm_hoogte
+        _new_data.buiten_berm_breedte = base_data.buiten_berm_breedte
+        _new_data.kruin_breedte = scenario.kruin_breedte
+        _new_data.kruin_hoogte = self._calculate_new_kruin_hoogte(base_data, scenario)
+        _new_data.binnen_maaiveld = base_data.binnen_maaiveld
+        _new_data.binnen_talud = self._calculate_new_binnen_talud(base_data, scenario)
+        _new_data.binnen_berm_breedte = vps_settings.binnen_berm_breedte_vps
+        _new_data.binnen_berm_hoogte = self._calculate_new_binnen_berm_hoogte(
+            base_data, _new_data, scenario
+        )
+        _new_data.grondprijs_bebouwd = base_data.grondprijs_bebouwd
+        _new_data.grondprijs_onbebouwd = base_data.grondprijs_onbebouwd
+        _new_data.factor_zetting = base_data.factor_zetting
+        _new_data.pleistoceen = base_data.pleistoceen
+        _new_data.aquifer = base_data.aquifer
+        _new_data.construction_type = ConstructionTypeEnum.VZG
+        _new_data.soil_surtax_factor = vps_settings.soil_surtax_factor
+        _new_data.constructive_surtax_factor = vps_settings.constructive_surtax_factor
+        _new_data.land_purchase_surtax_factor = vps_settings.land_purchase_surtax_factor
+        return _new_data
+
+    def build(self) -> VPSInputProfile:
+        return self._calculate_new_input_profile(
+            self.base_profile.input_data,
+            self.reinforcement_settings.vps_settings,
+            self.scenario,
+        )

--- a/koswat/dike_reinforcements/input_profile/vertical_piping_solution/vps_input_profile_calculation.py
+++ b/koswat/dike_reinforcements/input_profile/vertical_piping_solution/vps_input_profile_calculation.py
@@ -27,9 +27,6 @@ class VPSInputProfileCalculation(
     reinforcement_settings: KoswatReinforcementSettings
     scenario: KoswatScenario
 
-    def __init__(self) -> None:
-        super().__init__()
-
     def _calculate_new_input_profile(
         self,
         base_data: KoswatInputProfileBase,

--- a/koswat/dike_reinforcements/reinforcement_profile/standard/vps_reinforcement_profile.py
+++ b/koswat/dike_reinforcements/reinforcement_profile/standard/vps_reinforcement_profile.py
@@ -1,0 +1,21 @@
+from koswat.dike.koswat_profile_protocol import KoswatProfileProtocol
+from koswat.dike_reinforcements.input_profile.vertical_piping_solution.vps_input_profile import (
+    VPSInputProfile,
+)
+from koswat.dike_reinforcements.reinforcement_layers.reinforcement_layers_wrapper import (
+    ReinforcementLayersWrapper,
+)
+from koswat.dike_reinforcements.reinforcement_profile.standard.standard_reinforcement_profile import (
+    StandardReinforcementProfile,
+)
+
+
+class VPSReinforcementProfile(StandardReinforcementProfile):
+    output_name: str = "Verticale piping oplossing"
+    input_data: VPSInputProfile
+    layers_wrapper: ReinforcementLayersWrapper
+    old_profile: KoswatProfileProtocol
+    new_ground_level_surface: float
+
+    def __str__(self) -> str:
+        return self.output_name

--- a/tests/dike_reinforcements/input_profile/vertical_piping_solution/test_vps_input_profile_calculation.py
+++ b/tests/dike_reinforcements/input_profile/vertical_piping_solution/test_vps_input_profile_calculation.py
@@ -1,0 +1,67 @@
+import pytest
+
+from koswat.configuration.settings import KoswatScenario
+from koswat.configuration.settings.reinforcements.koswat_vps_settings import (
+    KoswatVPSSettings,
+)
+from koswat.core.protocols import BuilderProtocol
+from koswat.dike.profile.koswat_input_profile_base import KoswatInputProfileBase
+from koswat.dike_reinforcements.input_profile.reinforcement_input_profile_calculation_protocol import (
+    ReinforcementInputProfileCalculationProtocol,
+)
+from koswat.dike_reinforcements.input_profile.soil.soil_input_profile_calculation import (
+    SoilInputProfileCalculation,
+)
+from koswat.dike_reinforcements.input_profile.vertical_piping_solution.vps_input_profile_calculation import (
+    VPSInputProfileCalculation,
+)
+
+
+class TestVPSInputProfileCalculation:
+    def test_initialize(self):
+        _calculation = VPSInputProfileCalculation()
+        assert _calculation
+        assert not _calculation.base_profile
+        assert not _calculation.scenario
+        assert isinstance(_calculation, VPSInputProfileCalculation)
+        assert isinstance(_calculation, SoilInputProfileCalculation)
+        assert isinstance(_calculation, ReinforcementInputProfileCalculationProtocol)
+        assert isinstance(_calculation, BuilderProtocol)
+
+    def test_calculate_new_input_profile(self):
+        # 1. Define test data.
+        _scenario = KoswatScenario()
+        _scenario.d_h = 1
+        _scenario.d_p = 30
+        _scenario.kruin_breedte = 5
+        _scenario.buiten_talud = 3
+        _old_profile = KoswatInputProfileBase()
+        _old_profile.buiten_maaiveld = 0
+        _old_profile.buiten_talud = 3
+        _old_profile.buiten_berm_hoogte = 0
+        _old_profile.buiten_berm_breedte = 0
+        _old_profile.kruin_hoogte = 6
+        _old_profile.kruin_breedte = 5
+        _old_profile.binnen_talud = 3
+        _old_profile.binnen_berm_hoogte = 0
+        _old_profile.binnen_berm_breedte = 0
+        _old_profile.binnen_maaiveld = 0
+        _vps_settings = KoswatVPSSettings()
+        _vps_settings.binnen_berm_breedte_vps = 10
+
+        # 2. Run test
+        _new_profile = VPSInputProfileCalculation()._calculate_new_input_profile(
+            _old_profile, _vps_settings, _scenario
+        )
+
+        # 3. Verify expectations
+        assert _new_profile.buiten_maaiveld == _old_profile.buiten_maaiveld
+        assert _new_profile.buiten_talud == _old_profile.buiten_talud
+        assert _new_profile.buiten_berm_hoogte == _old_profile.buiten_berm_hoogte
+        assert _new_profile.buiten_berm_breedte == _old_profile.buiten_berm_breedte
+        assert _new_profile.kruin_hoogte == pytest.approx(7, 0.0001)
+        assert _new_profile.kruin_breedte == _scenario.kruin_breedte
+        assert _new_profile.binnen_talud == pytest.approx(3, 0.0001)
+        assert _new_profile.binnen_maaiveld == _old_profile.binnen_maaiveld
+        assert _new_profile.binnen_berm_breedte == pytest.approx(10, 0.0001)
+        assert _new_profile.binnen_berm_hoogte == pytest.approx(0.5, 0.0001)

--- a/tests/dike_reinforcements/reinforcement_profile/standard/test_vps_reinforcement_profile.py
+++ b/tests/dike_reinforcements/reinforcement_profile/standard/test_vps_reinforcement_profile.py
@@ -1,0 +1,21 @@
+from koswat.dike.koswat_profile_protocol import KoswatProfileProtocol
+from koswat.dike.profile.koswat_profile import KoswatProfileBase
+from koswat.dike_reinforcements.reinforcement_profile.reinforcement_profile_protocol import (
+    ReinforcementProfileProtocol,
+)
+from koswat.dike_reinforcements.reinforcement_profile.standard.standard_reinforcement_profile import (
+    StandardReinforcementProfile,
+)
+from koswat.dike_reinforcements.reinforcement_profile.standard.vps_reinforcement_profile import (
+    VPSReinforcementProfile,
+)
+
+
+class TestVPSReinforcementProfile:
+    def test_initialize(self):
+        _profile = VPSReinforcementProfile()
+        assert isinstance(_profile, VPSReinforcementProfile)
+        assert isinstance(_profile, StandardReinforcementProfile)
+        assert isinstance(_profile, ReinforcementProfileProtocol)
+        assert isinstance(_profile, KoswatProfileProtocol)
+        assert isinstance(_profile, KoswatProfileBase)


### PR DESCRIPTION
## Issue addressed
Solves #136

## Code of conduct
- [x] I HAVE NOT added sensitive or compromised (test) data to the repository.
- [x] I HAVE NOT added vulnerabilities to the repository.
- [ ] I HAVE discussed my solution with (other) members of the KOSWAT team.

## What has been done?
- The measure type is called Vertical Piping Solution (VPS), which is now only implemented with construction Vertical Sandproof Geotextile (VZG). In the future more different constructions could be added with different cost and/or dimensions.
- VPSInputProfile(Calculation) inherits from SoilInputProfile(Calculation) as it is just a slight variation on it. Exceptions:
  - take the `binnen_berm_breedte` from the config instead of calculating it
  - construction_type = `VZG`

### Checklist
- [x] Tests are either added or updated.
- [x] Branch is up to date with `master`.
- [x] Updated documentation if needed.

## Additional Notes (optional)
N.A.
