### PR TITLE
fix: surroundings matrix does not include entries between infrastructures

### DIFF
--- a/koswat/configuration/io/csv/koswat_surroundings_csv_reader.py
+++ b/koswat/configuration/io/csv/koswat_surroundings_csv_reader.py
@@ -50,14 +50,10 @@ class KoswatSurroundingsCsvReader(KoswatReaderProtocol):
         self, entry: list[str], distances_list: list[float]
     ) -> PointSurroundings:
         def csv_column_to_dict(csv_columns: list[str]) -> dict:
-            _surroundings_matrix = {}
-            for e_idx, e_val in enumerate(csv_columns):
-                _float_eval = float(e_val)
-                if _float_eval == 0:
-                    # We are not interested in 'cells' without 'value'.
-                    continue
-                _surroundings_matrix[distances_list[e_idx]] = _float_eval
-            return _surroundings_matrix
+            return {
+                distances_list[e_idx]: float(e_val)
+                for e_idx, e_val in enumerate(csv_columns)
+            }
 
         return PointSurroundings(
             section=entry[1],

--- a/koswat/configuration/io/csv/koswat_surroundings_csv_reader.py
+++ b/koswat/configuration/io/csv/koswat_surroundings_csv_reader.py
@@ -1,4 +1,6 @@
+import math
 import re
+from math import isclose
 from pathlib import Path
 
 from shapely import Point
@@ -50,10 +52,30 @@ class KoswatSurroundingsCsvReader(KoswatReaderProtocol):
         self, entry: list[str], distances_list: list[float]
     ) -> PointSurroundings:
         def csv_column_to_dict(csv_columns: list[str]) -> dict:
-            return {
-                distances_list[e_idx]: float(e_val)
-                for e_idx, e_val in enumerate(csv_columns)
-            }
+            """
+            (Koswat #172) To avoid adding more entries than required,
+             - only add keys whose weight is greater than zero,
+             - and the keys before them that are zero.
+            The keys with zeros act as a limit to avoid adding unnecessary costs
+            """
+            _tuples_for_dict = []
+
+            def last_tuple_had_weight() -> bool:
+                return any(_tuples_for_dict) and not math.isclose(
+                    _tuples_for_dict[0][1], 0
+                )
+
+            def can_add_item(weight: float) -> bool:
+                return weight > 0 or (
+                    math.isclose(weight, 0) and last_tuple_had_weight()
+                )
+
+            for e_idx, e_val in reversed(list(enumerate(csv_columns))):
+                _as_float = float(e_val)
+                if can_add_item(_as_float):
+                    _tuples_for_dict.insert(0, (distances_list[e_idx], _as_float))
+
+            return dict(_tuples_for_dict)
 
         return PointSurroundings(
             section=entry[1],

--- a/tests/configuration/io/csv/test_koswat_surroundings_csv_reader.py
+++ b/tests/configuration/io/csv/test_koswat_surroundings_csv_reader.py
@@ -5,6 +5,7 @@ from koswat.configuration.io.csv.koswat_surroundings_csv_reader import (
     KoswatSurroundingsCsvReader,
 )
 from koswat.core.io.koswat_reader_protocol import KoswatReaderProtocol
+from koswat.dike.surroundings.point.point_surroundings import PointSurroundings
 from tests import test_data
 
 
@@ -28,3 +29,33 @@ class TestKoswatSurroundingsCsvReader:
         # 3. Verify expectations.
         assert isinstance(_csv_fom, KoswatSurroundingsCsvFom)
         assert _csv_fom.is_valid()
+
+    def test_when_build_point_surroundings_then_reduced_surroundings_matrix(self):
+        # 1. Define test data.
+        _section = "Dummy"
+        _traject_order = -1
+        _location_x = 4.2
+        _location_y = 2.4
+        _distances_list = [5, 10, 15, 20, 25, 30, 35]
+        _distance_weights = [0, 0, 2, 0, 0, 4, 0]
+        _expected_matrix = {10: 0, 15: 2, 25: 0, 30: 4}
+
+        # 2. Run test.
+        _point_surroundings = KoswatSurroundingsCsvReader()._build_point_surroundings(
+            entry=[
+                _traject_order,
+                _section,
+                _location_x,
+                _location_y,
+                *_distance_weights,
+            ],
+            distances_list=_distances_list,
+        )
+
+        # 3. Verify expectations.
+        assert isinstance(_point_surroundings, PointSurroundings)
+        assert _point_surroundings.section == _section
+        assert _point_surroundings.traject_order == _traject_order
+        assert _point_surroundings.location.x == _location_x
+        assert _point_surroundings.location.y == _location_y
+        assert _point_surroundings.surroundings_matrix == _expected_matrix


### PR DESCRIPTION
## Issue addressed
Solves #172 

## Code of conduct
- [x] I HAVE NOT added sensitive or compromised (test) data to the repository.
- [x] I HAVE NOT added vulnerabilities to the repository.
- [x] I HAVE discussed my solution with (other) members of the KOSWAT team.

## What has been done?
- Improved the `_build_point_surroundings` so that includes the current entries (when values are greater than zero) and their immediate previous key that is also zero so that such key is found during calculations and therefore avoiding including weights outside the real affected reinforcement width.
- Added test verifying the behavior of the internal method.

### Checklist
- [x] Tests are either added or updated.
- [x] Branch is up to date with `master`.
- [x] Updated documentation if needed.

## Additional Notes (optional)
N.v.t.
