### PR TITLE
fix: 171 total infrastructure cost in summary costcsv seems to be wrong

### DIFF
--- a/koswat/cost_report/README.md
+++ b/koswat/cost_report/README.md
@@ -7,7 +7,8 @@ A cost report is generated given a `KoswatRunScenarioSettings` instance. Said re
 In addition to the cost report, an infrastructure report (`InfrastructureLocationProfileCostReport`) will be added based on the `InfrastructureSurroundingsWrapper` which will determine additional costs per reinforcment depending on whether the infrastructures need to be replaced or repaired.
 
 The defined hierarchy is such as: 
-- `KoswatSummary`: Wrapper of all multi-location-profile-cost-reports `MultiLocationProfileCostReport`.
-- `MultiLocationproFileCostReport`: Generates a profile-cost-report `ProfileCostReport`, based on a list of locations `PointSurroundings` and the compatible reinforcement profiles `ReinforcementProfileProtocol`.
-- `ProfileCostReport`: Contains a summary of the costs associated with its reinforced profile (`ReinforcementProfileProtocol`). It also contains a list of reports per-layer ( `LayerCostReport`).
+- `KoswatSummary`: Wrapper of all multi-location-profile-cost-reports `MultiLocationProfileCostReport` and strategy-location-reinforcements `StrategyLocationReinforcement`.
+- `MultiLocationProfileCostReport`: Generates a profile-cost-report `ProfileCostReport`, based on a list of locations `PointSurroundings` and the compatible reinforcement profiles `ReinforcementProfileProtocol`.
+- `ProfileCostReport`: Contains a summary of the costs associated with its reinforced profile (`ReinforcementProfileProtocol`). It also contains a list of reports per-layer (`LayerCostReport`).
 - `LayerCostReport`: A brief summary of the associated volumes and costs for a given `ReinforcementLayerProtocol`.
+- `StrategyLocationReinforcement`: Contains the available and selected reinforcement profiles per location `PointSurrounding`.

--- a/koswat/cost_report/infrastructure/infrastructure_location_profile_cost_report.py
+++ b/koswat/cost_report/infrastructure/infrastructure_location_profile_cost_report.py
@@ -31,7 +31,7 @@ class InfrastructureLocationProfileCostReport(CostReportProtocol):
     @property
     def total_cost(self) -> float:
         if not self.infrastructure_location_costs:
-            return 0
+            return 0.0
         return (
             self.infrastructure_location_costs.zone_a_costs
             + self.infrastructure_location_costs.zone_b_costs
@@ -40,5 +40,5 @@ class InfrastructureLocationProfileCostReport(CostReportProtocol):
     @property
     def total_cost_with_surtax(self) -> float:
         if not self.infrastructure_location_costs:
-            return 0
+            return 0.0
         return self.total_cost * self.infrastructure_location_costs.surtax

--- a/koswat/cost_report/io/summary/koswat_summary_exporter.py
+++ b/koswat/cost_report/io/summary/koswat_summary_exporter.py
@@ -1,4 +1,4 @@
-from click import Path
+from pathlib import Path
 
 from koswat.core.io.koswat_exporter_protocol import KoswatExporterProtocol
 from koswat.cost_report.io.summary.summary_costs.summary_costs_csv_exporter import (

--- a/koswat/cost_report/io/summary/summary_costs/summary_costs_csv_fom_builder.py
+++ b/koswat/cost_report/io/summary/summary_costs/summary_costs_csv_fom_builder.py
@@ -123,12 +123,8 @@ class SummaryCostsCsvFomBuilder(BuilderProtocol):
         infrastructure_cost: dict[str, list[float]],
     ) -> dict[str, list[float]]:
         def add_costs(measure_cost: list[float], infra_cost: list[float]):
-            def replace_nan(cost: list[float]) -> list[float]:
-                return [0 if math.isnan(x) else x for x in cost]
-
             return [
-                x + y
-                for x, y in zip(replace_nan(measure_cost), replace_nan(infra_cost))
+                round(x + y, self._decimals) for x, y in zip(measure_cost, infra_cost)
             ]
 
         _total_cost_key = "Total cost"
@@ -239,21 +235,19 @@ class SummaryCostsCsvFomBuilder(BuilderProtocol):
 
             _quantity_key = f"{_parameter_name} {self._quantity_key}:"
             csv_dictionary[_quantity_key].append(
-                round(_vc_parameter.quantity, self._decimals)
-                if _vc_parameter
-                else math.nan
+                round(_vc_parameter.quantity, self._decimals) if _vc_parameter else 0.0
             )
 
             _cost_key = f"{_parameter_name} {self._cost_key}:"
             csv_dictionary[_cost_key].append(
                 round(_vc_parameter.total_cost, self._decimals)
                 if _vc_parameter
-                else math.nan
+                else 0.0
             )
 
             _cost_with_surtax_key = f"{_parameter_name} {self._cost_with_surtax_key}:"
             csv_dictionary[_cost_with_surtax_key].append(
                 round(_vc_parameter.total_cost_with_surtax, self._decimals)
                 if _vc_parameter
-                else math.nan
+                else 0.0
             )

--- a/koswat/cost_report/io/summary/summary_costs/summary_costs_csv_fom_builder.py
+++ b/koswat/cost_report/io/summary/summary_costs/summary_costs_csv_fom_builder.py
@@ -151,19 +151,24 @@ class SummaryCostsCsvFomBuilder(BuilderProtocol):
         _infrastructure_cost_incl_surtax_key = "Infrastructure cost incl surtax"
         _infrastructure_rows = defaultdict(list)
 
+        # Cost per reinforcement type
         for _ordered_reinf in self._get_summary_reinforcement_type_column_order():
-            _report_by_profile = self.koswat_summary.get_report_by_profile(
-                _ordered_reinf
-            )
             _infrastructure_rows[_infrastructure_cost_key].append(
-                round(_report_by_profile.infrastructure_cost, self._decimals)
+                round(
+                    self.koswat_summary.get_infrastructure_cost(_ordered_reinf),
+                    self._decimals,
+                )
             )
             _infrastructure_rows[_infrastructure_cost_incl_surtax_key].append(
                 round(
-                    _report_by_profile.infrastructure_cost_with_surtax, self._decimals
+                    self.koswat_summary.get_infrastructure_cost_with_surtax(
+                        _ordered_reinf
+                    ),
+                    self._decimals,
                 )
             )
 
+        # Summary of cost per reinforcement type
         _infrastructure_rows[_infrastructure_cost_key].append(
             round(sum(_infrastructure_rows[_infrastructure_cost_key]), self._decimals)
         )
@@ -184,6 +189,8 @@ class SummaryCostsCsvFomBuilder(BuilderProtocol):
         _total_meters_per_selected_measure = (
             self._get_total_meters_per_selected_measure()
         )
+
+        # Cost per reinforcement type
         for _ordered_reinf in self._get_summary_reinforcement_type_column_order():
             _total_meters = _total_meters_per_selected_measure.get(_ordered_reinf, 0)
             _selected_measures_rows[_total_measure_meters_key].append(_total_meters)
@@ -203,6 +210,7 @@ class SummaryCostsCsvFomBuilder(BuilderProtocol):
                 round(_measure_cost_with_surtax, self._decimals)
             )
 
+        # Summary of cost per reinforcement type
         _selected_measures_rows[_total_measure_cost_key].append(
             round(sum(_selected_measures_rows[_total_measure_cost_key]), self._decimals)
         )

--- a/koswat/cost_report/multi_location_profile/multi_location_profile_cost_report.py
+++ b/koswat/cost_report/multi_location_profile/multi_location_profile_cost_report.py
@@ -48,21 +48,6 @@ class MultiLocationProfileCostReport(CostReportProtocol):
         )
 
     @property
-    def infrastructure_cost(self) -> float:
-        if not self.infra_multilocation_profile_cost_report:
-            return math.nan
-        return sum(x.total_cost for x in self.infra_multilocation_profile_cost_report)
-
-    @property
-    def infrastructure_cost_with_surtax(self) -> float:
-        if not self.infra_multilocation_profile_cost_report:
-            return math.nan
-        return sum(
-            x.total_cost_with_surtax
-            for x in self.infra_multilocation_profile_cost_report
-        )
-
-    @property
     def profile_type_name(self) -> str:
         if (
             not self.profile_cost_report

--- a/koswat/cost_report/summary/koswat_summary.py
+++ b/koswat/cost_report/summary/koswat_summary.py
@@ -76,8 +76,10 @@ class KoswatSummary:
         Returns:
             float: Infrastructure cost.
         """
-        _report = self.get_report_by_profile(profile_type)
         _locations = self.get_locations_by_profile(profile_type)
+        if not _locations:
+            return 0.0
+        _report = self.get_report_by_profile(profile_type)
         return sum(
             ilpcr.total_cost
             for ilpcr in _report.infra_multilocation_profile_cost_report
@@ -87,8 +89,10 @@ class KoswatSummary:
     def get_infrastructure_cost_with_surtax(
         self, profile_type: Type[ReinforcementProfileProtocol]
     ) -> float:
-        _report = self.get_report_by_profile(profile_type)
         _locations = self.get_locations_by_profile(profile_type)
+        if not _locations:
+            return 0.0
+        _report = self.get_report_by_profile(profile_type)
         return sum(
             ilpcr.total_cost_with_surtax
             for ilpcr in _report.infra_multilocation_profile_cost_report

--- a/koswat/cost_report/summary/koswat_summary.py
+++ b/koswat/cost_report/summary/koswat_summary.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field
 from typing import Type
 
 from koswat.cost_report.multi_location_profile import MultiLocationProfileCostReport
+from koswat.dike.surroundings.point.point_surroundings import PointSurroundings
 from koswat.dike_reinforcements.reinforcement_profile.reinforcement_profile_protocol import (
     ReinforcementProfileProtocol,
 )
@@ -24,6 +26,15 @@ class KoswatSummary:
     def get_report_by_profile(
         self, profile_type: Type[ReinforcementProfileProtocol]
     ) -> MultiLocationProfileCostReport | None:
+        """
+        Get the report for a specific profile type.
+
+        Args:
+            profile_type (Type[ReinforcementProfileProtocol]): Type of reinforcement profile.
+
+        Returns:
+            MultiLocationProfileCostReport | None: Report for the profile type.
+        """
         return next(
             (
                 _report
@@ -33,4 +44,53 @@ class KoswatSummary:
                 )
             ),
             None,
+        )
+
+    def get_locations_by_profile(
+        self, profile_type: Type[ReinforcementProfileProtocol]
+    ) -> list[PointSurroundings]:
+        """
+        Get the locations for which a specific profile type is selected.
+
+        Args:
+            profile_type (Type[ReinforcementProfileProtocol]): Type of reinforcement profile.
+
+        Returns:
+            list[PointSurroundings]: List of locations.
+        """
+        return [
+            _rpl.location
+            for _rpl in self.reinforcement_per_locations
+            if _rpl.selected_measure == profile_type
+        ]
+
+    def get_infrastructure_cost(
+        self, profile_type: Type[ReinforcementProfileProtocol]
+    ) -> float:
+        """
+        Get the infrastructure cost for those locations for which a specific profile type is selected.
+
+        Args:
+            profile_type (Type[ReinforcementProfileProtocol]): Type of reinforcement profile.
+
+        Returns:
+            float: Infrastructure cost.
+        """
+        _report = self.get_report_by_profile(profile_type)
+        _locations = self.get_locations_by_profile(profile_type)
+        return sum(
+            ilpcr.total_cost
+            for ilpcr in _report.infra_multilocation_profile_cost_report
+            if ilpcr.location in _locations
+        )
+
+    def get_infrastructure_cost_with_surtax(
+        self, profile_type: Type[ReinforcementProfileProtocol]
+    ) -> float:
+        _report = self.get_report_by_profile(profile_type)
+        _locations = self.get_locations_by_profile(profile_type)
+        return sum(
+            ilpcr.total_cost_with_surtax
+            for ilpcr in _report.infra_multilocation_profile_cost_report
+            if ilpcr.location in _locations
         )

--- a/koswat/cost_report/summary/koswat_summary.py
+++ b/koswat/cost_report/summary/koswat_summary.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import math
 from dataclasses import dataclass, field
 from typing import Type
 

--- a/koswat/strategies/README.md
+++ b/koswat/strategies/README.md
@@ -4,7 +4,7 @@ This modules contains the logic to choose which measure will be applied for a gi
 
 - `StrategyInput`, wraps all required properties to apply a strategy: 
     - locations_matrix (`dict[PointSurroundings, list[Type[ReinforcementProfileProtocol]]]`), contains all the available reinforcements that can be applied at each location.
-    - structure_min_buffer (`float`), how many extra meters a structure requires for support its reinforcement.
+    - structure_min_buffer (`float`), how many extra meters a structure requires to support its reinforcement.
     - structure_min_length (`float`), how many minimal meters are required for a structure to "exist". This rule can, at times, have certain exceptions.
 
 - `StrategyLocationReinforcement`, represents a mapped location to a selected measure.

--- a/tests/cost_report/io/summary/summary_costs/test_summary_costs_csv_exporter.py
+++ b/tests/cost_report/io/summary/summary_costs/test_summary_costs_csv_exporter.py
@@ -34,47 +34,47 @@ class TestSummaryCostsCsvExporter:
         _expected_text = """Profile type;Kistdam;Kwelscherm;Grondmaatregel profiel;Stabiliteitswand
 Cost per km (Euro/km);0.0;8144.4;16288.8;24433.2
 Cost per km incl surtax (Euro/km);0.0;12216.6;24433.2;36649.8
-New grass volume (quantity):;nan;nan;nan;nan
-New grass volume (cost):;nan;nan;nan;nan
-New grass volume (cost incl surtax):;nan;nan;nan;nan
-New clay volume (quantity):;nan;nan;nan;nan
-New clay volume (cost):;nan;nan;nan;nan
-New clay volume (cost incl surtax):;nan;nan;nan;nan
-New core volume (quantity):;nan;nan;nan;nan
-New core volume (cost):;nan;nan;nan;nan
-New core volume (cost incl surtax):;nan;nan;nan;nan
-Reused grass volume (quantity):;nan;nan;nan;nan
-Reused grass volume (cost):;nan;nan;nan;nan
-Reused grass volume (cost incl surtax):;nan;nan;nan;nan
-Reused core volume (quantity):;nan;nan;nan;nan
-Reused core volume (cost):;nan;nan;nan;nan
-Reused core volume (cost incl surtax):;nan;nan;nan;nan
-Removed material volume (quantity):;nan;nan;nan;nan
-Removed material volume (cost):;nan;nan;nan;nan
-Removed material volume (cost incl surtax):;nan;nan;nan;nan
-New grass layer surface (quantity):;nan;nan;nan;nan
-New grass layer surface (cost):;nan;nan;nan;nan
-New grass layer surface (cost incl surtax):;nan;nan;nan;nan
-New clay layer surface (quantity):;nan;nan;nan;nan
-New clay layer surface (cost):;nan;nan;nan;nan
-New clay layer surface (cost incl surtax):;nan;nan;nan;nan
-New core layer surface (quantity):;nan;nan;nan;nan
-New core layer surface (cost):;nan;nan;nan;nan
-New core layer surface (cost incl surtax):;nan;nan;nan;nan
-New maaiveld surface (quantity):;nan;nan;nan;nan
-New maaiveld surface (cost):;nan;nan;nan;nan
-New maaiveld surface (cost incl surtax):;nan;nan;nan;nan
-Land purchase surface (quantity):;nan;nan;nan;nan
-Land purchase surface (cost):;nan;nan;nan;nan
-Land purchase surface (cost incl surtax):;nan;nan;nan;nan
-Construction length (quantity):;nan;nan;nan;nan
-Construction length (cost):;nan;nan;nan;nan
-Construction length (cost incl surtax):;nan;nan;nan;nan
+New grass volume (quantity):;0.0;0.0;0.0;0.0
+New grass volume (cost):;0.0;0.0;0.0;0.0
+New grass volume (cost incl surtax):;0.0;0.0;0.0;0.0
+New clay volume (quantity):;0.0;0.0;0.0;0.0
+New clay volume (cost):;0.0;0.0;0.0;0.0
+New clay volume (cost incl surtax):;0.0;0.0;0.0;0.0
+New core volume (quantity):;0.0;0.0;0.0;0.0
+New core volume (cost):;0.0;0.0;0.0;0.0
+New core volume (cost incl surtax):;0.0;0.0;0.0;0.0
+Reused grass volume (quantity):;0.0;0.0;0.0;0.0
+Reused grass volume (cost):;0.0;0.0;0.0;0.0
+Reused grass volume (cost incl surtax):;0.0;0.0;0.0;0.0
+Reused core volume (quantity):;0.0;0.0;0.0;0.0
+Reused core volume (cost):;0.0;0.0;0.0;0.0
+Reused core volume (cost incl surtax):;0.0;0.0;0.0;0.0
+Removed material volume (quantity):;0.0;0.0;0.0;0.0
+Removed material volume (cost):;0.0;0.0;0.0;0.0
+Removed material volume (cost incl surtax):;0.0;0.0;0.0;0.0
+New grass layer surface (quantity):;0.0;0.0;0.0;0.0
+New grass layer surface (cost):;0.0;0.0;0.0;0.0
+New grass layer surface (cost incl surtax):;0.0;0.0;0.0;0.0
+New clay layer surface (quantity):;0.0;0.0;0.0;0.0
+New clay layer surface (cost):;0.0;0.0;0.0;0.0
+New clay layer surface (cost incl surtax):;0.0;0.0;0.0;0.0
+New core layer surface (quantity):;0.0;0.0;0.0;0.0
+New core layer surface (cost):;0.0;0.0;0.0;0.0
+New core layer surface (cost incl surtax):;0.0;0.0;0.0;0.0
+New maaiveld surface (quantity):;0.0;0.0;0.0;0.0
+New maaiveld surface (cost):;0.0;0.0;0.0;0.0
+New maaiveld surface (cost incl surtax):;0.0;0.0;0.0;0.0
+Land purchase surface (quantity):;0.0;0.0;0.0;0.0
+Land purchase surface (cost):;0.0;0.0;0.0;0.0
+Land purchase surface (cost incl surtax):;0.0;0.0;0.0;0.0
+Construction length (quantity):;0.0;0.0;0.0;0.0
+Construction length (cost):;0.0;0.0;0.0;0.0
+Construction length (cost incl surtax):;0.0;0.0;0.0;0.0
 Total measure meters;0;1;1;2
 Total measure cost;0.0;8.14;16.29;48.87;73.3
 Total measure cost incl surtax;0.0;12.22;24.43;73.3;109.95
-Infrastructure cost;39.6;39.6;39.6;39.6;158.4
-Infrastructure cost incl surtax;277.2;277.2;277.2;277.2;1108.8
-Total cost;39.6;47.74;55.89;88.47;231.7
-Total cost incl surtax;277.2;289.42;301.63;350.5;1218.75"""
+Infrastructure cost;0.0;0.0;6.6;33.0;39.6
+Infrastructure cost incl surtax;0.0;0.0;19.8;257.4;277.2
+Total cost;0.0;8.14;22.89;81.87;112.9
+Total cost incl surtax;0.0;12.22;44.23;330.7;387.15"""
         assert _expected_text == _read_text

--- a/tests/test_data/acceptance_reference_data/case_dijk1_1a_dh_with_default_layers/summary_costs.csv
+++ b/tests/test_data/acceptance_reference_data/case_dijk1_1a_dh_with_default_layers/summary_costs.csv
@@ -40,7 +40,7 @@ Construction length (cost incl surtax):;0;1456.0;0.0;0.0;0.0
 Total measure meters;0;0;0;0;0
 Total measure cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total measure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
-Infrastructure cost;nan;nan;nan;nan;nan;nan
-Infrastructure cost incl surtax;nan;nan;nan;nan;nan;nan
+Infrastructure cost;0.0;0.0;0.0;0.0;0.0;0.0
+Infrastructure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0

--- a/tests/test_data/acceptance_reference_data/case_dijk1_1b_ds_with_default_layers/summary_costs.csv
+++ b/tests/test_data/acceptance_reference_data/case_dijk1_1b_ds_with_default_layers/summary_costs.csv
@@ -40,7 +40,7 @@ Construction length (cost incl surtax):;0;1456.0;0.0;0.0;0.0
 Total measure meters;0;0;0;0;0
 Total measure cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total measure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
-Infrastructure cost;nan;nan;nan;nan;nan;nan
-Infrastructure cost incl surtax;nan;nan;nan;nan;nan;nan
+Infrastructure cost;0.0;0.0;0.0;0.0;0.0;0.0
+Infrastructure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0

--- a/tests/test_data/acceptance_reference_data/case_dijk1_1c_dp_with_default_layers/summary_costs.csv
+++ b/tests/test_data/acceptance_reference_data/case_dijk1_1c_dp_with_default_layers/summary_costs.csv
@@ -40,7 +40,7 @@ Construction length (cost incl surtax):;0;1456.0;2821.61;12417.58;25550.72
 Total measure meters;0;0;0;0;0
 Total measure cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total measure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
-Infrastructure cost;nan;nan;nan;nan;nan;nan
-Infrastructure cost incl surtax;nan;nan;nan;nan;nan;nan
+Infrastructure cost;0.0;0.0;0.0;0.0;0.0;0.0
+Infrastructure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0

--- a/tests/test_data/acceptance_reference_data/case_dijk1_1d_dhds_with_default_layers/summary_costs.csv
+++ b/tests/test_data/acceptance_reference_data/case_dijk1_1d_dhds_with_default_layers/summary_costs.csv
@@ -40,7 +40,7 @@ Construction length (cost incl surtax):;0;1456.0;0.0;0.0;0.0
 Total measure meters;0;0;0;0;0
 Total measure cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total measure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
-Infrastructure cost;nan;nan;nan;nan;nan;nan
-Infrastructure cost incl surtax;nan;nan;nan;nan;nan;nan
+Infrastructure cost;0.0;0.0;0.0;0.0;0.0;0.0
+Infrastructure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0

--- a/tests/test_data/acceptance_reference_data/case_dijk1_1e_dhdp_with_default_layers/summary_costs.csv
+++ b/tests/test_data/acceptance_reference_data/case_dijk1_1e_dhdp_with_default_layers/summary_costs.csv
@@ -40,7 +40,7 @@ Construction length (cost incl surtax):;0;1456.0;2821.61;12954.77;26672.31
 Total measure meters;0;0;0;0;0
 Total measure cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total measure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
-Infrastructure cost;nan;nan;nan;nan;nan;nan
-Infrastructure cost incl surtax;nan;nan;nan;nan;nan;nan
+Infrastructure cost;0.0;0.0;0.0;0.0;0.0;0.0
+Infrastructure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0

--- a/tests/test_data/acceptance_reference_data/case_dijk1_1f_dsdp_with_default_layers/summary_costs.csv
+++ b/tests/test_data/acceptance_reference_data/case_dijk1_1f_dsdp_with_default_layers/summary_costs.csv
@@ -40,7 +40,7 @@ Construction length (cost incl surtax):;0;1456.0;2821.61;12738.27;26223.67
 Total measure meters;0;0;0;0;0
 Total measure cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total measure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
-Infrastructure cost;nan;nan;nan;nan;nan;nan
-Infrastructure cost incl surtax;nan;nan;nan;nan;nan;nan
+Infrastructure cost;0.0;0.0;0.0;0.0;0.0;0.0
+Infrastructure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0

--- a/tests/test_data/acceptance_reference_data/case_dijk1_1g_dhdsdp_with_default_layers/summary_costs.csv
+++ b/tests/test_data/acceptance_reference_data/case_dijk1_1g_dhdsdp_with_default_layers/summary_costs.csv
@@ -40,7 +40,7 @@ Construction length (cost incl surtax):;0;1456.0;2821.61;13955.84;28691.17
 Total measure meters;0;0;0;0;0
 Total measure cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total measure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
-Infrastructure cost;nan;nan;nan;nan;nan;nan
-Infrastructure cost incl surtax;nan;nan;nan;nan;nan;nan
+Infrastructure cost;0.0;0.0;0.0;0.0;0.0;0.0
+Infrastructure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0

--- a/tests/test_data/acceptance_reference_data/case_dijk1_2a_dh_with_default_layers/summary_costs.csv
+++ b/tests/test_data/acceptance_reference_data/case_dijk1_2a_dh_with_default_layers/summary_costs.csv
@@ -40,7 +40,7 @@ Construction length (cost incl surtax):;0;1456.0;0.0;0.0;0.0
 Total measure meters;0;0;0;0;0
 Total measure cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total measure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
-Infrastructure cost;nan;nan;nan;nan;nan;nan
-Infrastructure cost incl surtax;nan;nan;nan;nan;nan;nan
+Infrastructure cost;0.0;0.0;0.0;0.0;0.0;0.0
+Infrastructure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0

--- a/tests/test_data/acceptance_reference_data/case_dijk1_2b_ds_with_default_layers/summary_costs.csv
+++ b/tests/test_data/acceptance_reference_data/case_dijk1_2b_ds_with_default_layers/summary_costs.csv
@@ -40,7 +40,7 @@ Construction length (cost incl surtax):;0;1456.0;0.0;0.0;0.0
 Total measure meters;0;0;0;0;0
 Total measure cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total measure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
-Infrastructure cost;nan;nan;nan;nan;nan;nan
-Infrastructure cost incl surtax;nan;nan;nan;nan;nan;nan
+Infrastructure cost;0.0;0.0;0.0;0.0;0.0;0.0
+Infrastructure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0

--- a/tests/test_data/acceptance_reference_data/case_dijk1_2c_dp_with_default_layers/summary_costs.csv
+++ b/tests/test_data/acceptance_reference_data/case_dijk1_2c_dp_with_default_layers/summary_costs.csv
@@ -40,7 +40,7 @@ Construction length (cost incl surtax):;0;1456.0;5141.4;17479.87;35196.38
 Total measure meters;0;0;0;0;0
 Total measure cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total measure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
-Infrastructure cost;nan;nan;nan;nan;nan;nan
-Infrastructure cost incl surtax;nan;nan;nan;nan;nan;nan
+Infrastructure cost;0.0;0.0;0.0;0.0;0.0;0.0
+Infrastructure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0

--- a/tests/test_data/acceptance_reference_data/case_dijk1_2d_dhds_with_default_layers/summary_costs.csv
+++ b/tests/test_data/acceptance_reference_data/case_dijk1_2d_dhds_with_default_layers/summary_costs.csv
@@ -40,7 +40,7 @@ Construction length (cost incl surtax):;0;1456.0;0.0;0.0;0.0
 Total measure meters;0;0;0;0;0
 Total measure cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total measure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
-Infrastructure cost;nan;nan;nan;nan;nan;nan
-Infrastructure cost incl surtax;nan;nan;nan;nan;nan;nan
+Infrastructure cost;0.0;0.0;0.0;0.0;0.0;0.0
+Infrastructure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0

--- a/tests/test_data/acceptance_reference_data/case_dijk1_2e_dhdp_with_default_layers/summary_costs.csv
+++ b/tests/test_data/acceptance_reference_data/case_dijk1_2e_dhdp_with_default_layers/summary_costs.csv
@@ -40,7 +40,7 @@ Construction length (cost incl surtax):;0;1456.0;5141.4;20175.58;39682.73
 Total measure meters;0;0;0;0;0
 Total measure cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total measure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
-Infrastructure cost;nan;nan;nan;nan;nan;nan
-Infrastructure cost incl surtax;nan;nan;nan;nan;nan;nan
+Infrastructure cost;0.0;0.0;0.0;0.0;0.0;0.0
+Infrastructure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0

--- a/tests/test_data/acceptance_reference_data/case_dijk1_2f_dsdp_with_default_layers/summary_costs.csv
+++ b/tests/test_data/acceptance_reference_data/case_dijk1_2f_dsdp_with_default_layers/summary_costs.csv
@@ -40,7 +40,7 @@ Construction length (cost incl surtax):;0;1456.0;5141.4;19481.34;38561.14
 Total measure meters;0;0;0;0;0
 Total measure cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total measure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
-Infrastructure cost;nan;nan;nan;nan;nan;nan
-Infrastructure cost incl surtax;nan;nan;nan;nan;nan;nan
+Infrastructure cost;0.0;0.0;0.0;0.0;0.0;0.0
+Infrastructure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0

--- a/tests/test_data/acceptance_reference_data/case_dijk1_2g_dhdsdp_with_default_layers/summary_costs.csv
+++ b/tests/test_data/acceptance_reference_data/case_dijk1_2g_dhdsdp_with_default_layers/summary_costs.csv
@@ -40,7 +40,7 @@ Construction length (cost incl surtax):;0;1456.0;5141.4;22786.91;43720.45
 Total measure meters;0;0;0;0;0
 Total measure cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total measure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
-Infrastructure cost;nan;nan;nan;nan;nan;nan
-Infrastructure cost incl surtax;nan;nan;nan;nan;nan;nan
+Infrastructure cost;0.0;0.0;0.0;0.0;0.0;0.0
+Infrastructure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0

--- a/tests/test_data/acceptance_reference_data/case_dijk2_1a_dh_with_default_layers/summary_costs.csv
+++ b/tests/test_data/acceptance_reference_data/case_dijk2_1a_dh_with_default_layers/summary_costs.csv
@@ -40,7 +40,7 @@ Construction length (cost incl surtax):;0;1456.0;0.0;0.0;0.0
 Total measure meters;0;0;0;0;0
 Total measure cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total measure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
-Infrastructure cost;nan;nan;nan;nan;nan;nan
-Infrastructure cost incl surtax;nan;nan;nan;nan;nan;nan
+Infrastructure cost;0.0;0.0;0.0;0.0;0.0;0.0
+Infrastructure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0

--- a/tests/test_data/acceptance_reference_data/case_dijk2_1b_ds_with_default_layers/summary_costs.csv
+++ b/tests/test_data/acceptance_reference_data/case_dijk2_1b_ds_with_default_layers/summary_costs.csv
@@ -40,7 +40,7 @@ Construction length (cost incl surtax):;0;1456.0;0.0;0.0;0.0
 Total measure meters;0;0;0;0;0
 Total measure cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total measure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
-Infrastructure cost;nan;nan;nan;nan;nan;nan
-Infrastructure cost incl surtax;nan;nan;nan;nan;nan;nan
+Infrastructure cost;0.0;0.0;0.0;0.0;0.0;0.0
+Infrastructure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0

--- a/tests/test_data/acceptance_reference_data/case_dijk2_1c_dp_with_default_layers/summary_costs.csv
+++ b/tests/test_data/acceptance_reference_data/case_dijk2_1c_dp_with_default_layers/summary_costs.csv
@@ -40,7 +40,7 @@ Construction length (cost incl surtax):;0;1456.0;2821.61;12417.58;25550.72
 Total measure meters;0;0;0;0;0
 Total measure cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total measure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
-Infrastructure cost;nan;nan;nan;nan;nan;nan
-Infrastructure cost incl surtax;nan;nan;nan;nan;nan;nan
+Infrastructure cost;0.0;0.0;0.0;0.0;0.0;0.0
+Infrastructure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0

--- a/tests/test_data/acceptance_reference_data/case_dijk2_1d_dhds_with_default_layers/summary_costs.csv
+++ b/tests/test_data/acceptance_reference_data/case_dijk2_1d_dhds_with_default_layers/summary_costs.csv
@@ -40,7 +40,7 @@ Construction length (cost incl surtax):;0;1456.0;0.0;0.0;0.0
 Total measure meters;0;0;0;0;0
 Total measure cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total measure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
-Infrastructure cost;nan;nan;nan;nan;nan;nan
-Infrastructure cost incl surtax;nan;nan;nan;nan;nan;nan
+Infrastructure cost;0.0;0.0;0.0;0.0;0.0;0.0
+Infrastructure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0

--- a/tests/test_data/acceptance_reference_data/case_dijk2_1e_dhdp_with_default_layers/summary_costs.csv
+++ b/tests/test_data/acceptance_reference_data/case_dijk2_1e_dhdp_with_default_layers/summary_costs.csv
@@ -40,7 +40,7 @@ Construction length (cost incl surtax):;0;1456.0;2821.61;12954.77;26672.31
 Total measure meters;0;0;0;0;0
 Total measure cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total measure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
-Infrastructure cost;nan;nan;nan;nan;nan;nan
-Infrastructure cost incl surtax;nan;nan;nan;nan;nan;nan
+Infrastructure cost;0.0;0.0;0.0;0.0;0.0;0.0
+Infrastructure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0

--- a/tests/test_data/acceptance_reference_data/case_dijk2_1f_dsdp_with_default_layers/summary_costs.csv
+++ b/tests/test_data/acceptance_reference_data/case_dijk2_1f_dsdp_with_default_layers/summary_costs.csv
@@ -40,7 +40,7 @@ Construction length (cost incl surtax):;0;1456.0;2821.61;12738.27;26223.67
 Total measure meters;0;0;0;0;0
 Total measure cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total measure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
-Infrastructure cost;nan;nan;nan;nan;nan;nan
-Infrastructure cost incl surtax;nan;nan;nan;nan;nan;nan
+Infrastructure cost;0.0;0.0;0.0;0.0;0.0;0.0
+Infrastructure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0

--- a/tests/test_data/acceptance_reference_data/case_dijk2_1g_dhdsdp_with_default_layers/summary_costs.csv
+++ b/tests/test_data/acceptance_reference_data/case_dijk2_1g_dhdsdp_with_default_layers/summary_costs.csv
@@ -40,7 +40,7 @@ Construction length (cost incl surtax):;0;1456.0;2821.61;13955.84;28691.17
 Total measure meters;0;0;0;0;0
 Total measure cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total measure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
-Infrastructure cost;nan;nan;nan;nan;nan;nan
-Infrastructure cost incl surtax;nan;nan;nan;nan;nan;nan
+Infrastructure cost;0.0;0.0;0.0;0.0;0.0;0.0
+Infrastructure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0

--- a/tests/test_data/acceptance_reference_data/case_dijk2_2a_dh_with_default_layers/summary_costs.csv
+++ b/tests/test_data/acceptance_reference_data/case_dijk2_2a_dh_with_default_layers/summary_costs.csv
@@ -40,7 +40,7 @@ Construction length (cost incl surtax):;0;1456.0;0.0;0.0;0.0
 Total measure meters;0;0;0;0;0
 Total measure cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total measure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
-Infrastructure cost;nan;nan;nan;nan;nan;nan
-Infrastructure cost incl surtax;nan;nan;nan;nan;nan;nan
+Infrastructure cost;0.0;0.0;0.0;0.0;0.0;0.0
+Infrastructure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0

--- a/tests/test_data/acceptance_reference_data/case_dijk2_2b_ds_with_default_layers/summary_costs.csv
+++ b/tests/test_data/acceptance_reference_data/case_dijk2_2b_ds_with_default_layers/summary_costs.csv
@@ -40,7 +40,7 @@ Construction length (cost incl surtax):;0;1456.0;0.0;0.0;0.0
 Total measure meters;0;0;0;0;0
 Total measure cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total measure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
-Infrastructure cost;nan;nan;nan;nan;nan;nan
-Infrastructure cost incl surtax;nan;nan;nan;nan;nan;nan
+Infrastructure cost;0.0;0.0;0.0;0.0;0.0;0.0
+Infrastructure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0

--- a/tests/test_data/acceptance_reference_data/case_dijk2_2c_dp_with_default_layers/summary_costs.csv
+++ b/tests/test_data/acceptance_reference_data/case_dijk2_2c_dp_with_default_layers/summary_costs.csv
@@ -40,7 +40,7 @@ Construction length (cost incl surtax):;0;1456.0;5141.4;17479.87;35196.38
 Total measure meters;0;0;0;0;0
 Total measure cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total measure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
-Infrastructure cost;nan;nan;nan;nan;nan;nan
-Infrastructure cost incl surtax;nan;nan;nan;nan;nan;nan
+Infrastructure cost;0.0;0.0;0.0;0.0;0.0;0.0
+Infrastructure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0

--- a/tests/test_data/acceptance_reference_data/case_dijk2_2d_dhds_with_default_layers/summary_costs.csv
+++ b/tests/test_data/acceptance_reference_data/case_dijk2_2d_dhds_with_default_layers/summary_costs.csv
@@ -40,7 +40,7 @@ Construction length (cost incl surtax):;0;1456.0;0.0;0.0;0.0
 Total measure meters;0;0;0;0;0
 Total measure cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total measure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
-Infrastructure cost;nan;nan;nan;nan;nan;nan
-Infrastructure cost incl surtax;nan;nan;nan;nan;nan;nan
+Infrastructure cost;0.0;0.0;0.0;0.0;0.0;0.0
+Infrastructure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0

--- a/tests/test_data/acceptance_reference_data/case_dijk2_2e_dhdp_with_default_layers/summary_costs.csv
+++ b/tests/test_data/acceptance_reference_data/case_dijk2_2e_dhdp_with_default_layers/summary_costs.csv
@@ -40,7 +40,7 @@ Construction length (cost incl surtax):;0;1456.0;5141.4;20175.58;39682.73
 Total measure meters;0;0;0;0;0
 Total measure cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total measure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
-Infrastructure cost;nan;nan;nan;nan;nan;nan
-Infrastructure cost incl surtax;nan;nan;nan;nan;nan;nan
+Infrastructure cost;0.0;0.0;0.0;0.0;0.0;0.0
+Infrastructure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0

--- a/tests/test_data/acceptance_reference_data/case_dijk2_2f_dsdp_with_default_layers/summary_costs.csv
+++ b/tests/test_data/acceptance_reference_data/case_dijk2_2f_dsdp_with_default_layers/summary_costs.csv
@@ -40,7 +40,7 @@ Construction length (cost incl surtax):;0;1456.0;5141.4;19481.34;38561.14
 Total measure meters;0;0;0;0;0
 Total measure cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total measure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
-Infrastructure cost;nan;nan;nan;nan;nan;nan
-Infrastructure cost incl surtax;nan;nan;nan;nan;nan;nan
+Infrastructure cost;0.0;0.0;0.0;0.0;0.0;0.0
+Infrastructure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0

--- a/tests/test_data/acceptance_reference_data/case_dijk2_2g_dhdsdp_with_default_layers/summary_costs.csv
+++ b/tests/test_data/acceptance_reference_data/case_dijk2_2g_dhdsdp_with_default_layers/summary_costs.csv
@@ -40,7 +40,7 @@ Construction length (cost incl surtax):;0;1456.0;5141.4;22786.91;43720.45
 Total measure meters;0;0;0;0;0
 Total measure cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total measure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
-Infrastructure cost;nan;nan;nan;nan;nan;nan
-Infrastructure cost incl surtax;nan;nan;nan;nan;nan;nan
+Infrastructure cost;0.0;0.0;0.0;0.0;0.0;0.0
+Infrastructure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0

--- a/tests/test_data/acceptance_reference_data/case_dijk3_1a_dh_with_default_layers/summary_costs.csv
+++ b/tests/test_data/acceptance_reference_data/case_dijk3_1a_dh_with_default_layers/summary_costs.csv
@@ -40,7 +40,7 @@ Construction length (cost incl surtax):;0;1456.0;0.0;0.0;0.0
 Total measure meters;0;0;0;0;0
 Total measure cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total measure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
-Infrastructure cost;nan;nan;nan;nan;nan;nan
-Infrastructure cost incl surtax;nan;nan;nan;nan;nan;nan
+Infrastructure cost;0.0;0.0;0.0;0.0;0.0;0.0
+Infrastructure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0

--- a/tests/test_data/acceptance_reference_data/case_dijk3_1b_ds_with_default_layers/summary_costs.csv
+++ b/tests/test_data/acceptance_reference_data/case_dijk3_1b_ds_with_default_layers/summary_costs.csv
@@ -40,7 +40,7 @@ Construction length (cost incl surtax):;0;1456.0;0.0;0.0;0.0
 Total measure meters;0;0;0;0;0
 Total measure cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total measure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
-Infrastructure cost;nan;nan;nan;nan;nan;nan
-Infrastructure cost incl surtax;nan;nan;nan;nan;nan;nan
+Infrastructure cost;0.0;0.0;0.0;0.0;0.0;0.0
+Infrastructure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0

--- a/tests/test_data/acceptance_reference_data/case_dijk3_1c_dp_with_default_layers/summary_costs.csv
+++ b/tests/test_data/acceptance_reference_data/case_dijk3_1c_dp_with_default_layers/summary_costs.csv
@@ -40,7 +40,7 @@ Construction length (cost incl surtax):;0;1456.0;1893.7;12417.58;25550.72
 Total measure meters;0;0;0;0;0
 Total measure cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total measure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
-Infrastructure cost;nan;nan;nan;nan;nan;nan
-Infrastructure cost incl surtax;nan;nan;nan;nan;nan;nan
+Infrastructure cost;0.0;0.0;0.0;0.0;0.0;0.0
+Infrastructure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0

--- a/tests/test_data/acceptance_reference_data/case_dijk3_1d_dhds_with_default_layers/summary_costs.csv
+++ b/tests/test_data/acceptance_reference_data/case_dijk3_1d_dhds_with_default_layers/summary_costs.csv
@@ -40,7 +40,7 @@ Construction length (cost incl surtax):;0;1456.0;0.0;0.0;0.0
 Total measure meters;0;0;0;0;0
 Total measure cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total measure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
-Infrastructure cost;nan;nan;nan;nan;nan;nan
-Infrastructure cost incl surtax;nan;nan;nan;nan;nan;nan
+Infrastructure cost;0.0;0.0;0.0;0.0;0.0;0.0
+Infrastructure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0

--- a/tests/test_data/acceptance_reference_data/case_dijk3_1e_dhdp_with_default_layers/summary_costs.csv
+++ b/tests/test_data/acceptance_reference_data/case_dijk3_1e_dhdp_with_default_layers/summary_costs.csv
@@ -40,7 +40,7 @@ Construction length (cost incl surtax):;0;1456.0;1893.7;12954.77;26672.31
 Total measure meters;0;0;0;0;0
 Total measure cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total measure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
-Infrastructure cost;nan;nan;nan;nan;nan;nan
-Infrastructure cost incl surtax;nan;nan;nan;nan;nan;nan
+Infrastructure cost;0.0;0.0;0.0;0.0;0.0;0.0
+Infrastructure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0

--- a/tests/test_data/acceptance_reference_data/case_dijk3_1f_dsdp_with_default_layers/summary_costs.csv
+++ b/tests/test_data/acceptance_reference_data/case_dijk3_1f_dsdp_with_default_layers/summary_costs.csv
@@ -40,7 +40,7 @@ Construction length (cost incl surtax):;0;1456.0;1893.7;13173.44;27120.94
 Total measure meters;0;0;0;0;0
 Total measure cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total measure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
-Infrastructure cost;nan;nan;nan;nan;nan;nan
-Infrastructure cost incl surtax;nan;nan;nan;nan;nan;nan
+Infrastructure cost;0.0;0.0;0.0;0.0;0.0;0.0
+Infrastructure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0

--- a/tests/test_data/acceptance_reference_data/case_dijk3_1g_dhdsdp_with_default_layers/summary_costs.csv
+++ b/tests/test_data/acceptance_reference_data/case_dijk3_1g_dhdsdp_with_default_layers/summary_costs.csv
@@ -40,7 +40,7 @@ Construction length (cost incl surtax):;0;1456.0;1893.7;14299.28;29364.12
 Total measure meters;0;0;0;0;0
 Total measure cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total measure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
-Infrastructure cost;nan;nan;nan;nan;nan;nan
-Infrastructure cost incl surtax;nan;nan;nan;nan;nan;nan
+Infrastructure cost;0.0;0.0;0.0;0.0;0.0;0.0
+Infrastructure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0

--- a/tests/test_data/acceptance_reference_data/case_dijk3_2a_dh_with_default_layers/summary_costs.csv
+++ b/tests/test_data/acceptance_reference_data/case_dijk3_2a_dh_with_default_layers/summary_costs.csv
@@ -40,7 +40,7 @@ Construction length (cost incl surtax):;0;1456.0;0.0;0.0;0.0
 Total measure meters;0;0;0;0;0
 Total measure cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total measure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
-Infrastructure cost;nan;nan;nan;nan;nan;nan
-Infrastructure cost incl surtax;nan;nan;nan;nan;nan;nan
+Infrastructure cost;0.0;0.0;0.0;0.0;0.0;0.0
+Infrastructure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0

--- a/tests/test_data/acceptance_reference_data/case_dijk3_2b_ds_with_default_layers/summary_costs.csv
+++ b/tests/test_data/acceptance_reference_data/case_dijk3_2b_ds_with_default_layers/summary_costs.csv
@@ -40,7 +40,7 @@ Construction length (cost incl surtax):;0;1456.0;0.0;0.0;0.0
 Total measure meters;0;0;0;0;0
 Total measure cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total measure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
-Infrastructure cost;nan;nan;nan;nan;nan;nan
-Infrastructure cost incl surtax;nan;nan;nan;nan;nan;nan
+Infrastructure cost;0.0;0.0;0.0;0.0;0.0;0.0
+Infrastructure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0

--- a/tests/test_data/acceptance_reference_data/case_dijk3_2c_dp_with_default_layers/summary_costs.csv
+++ b/tests/test_data/acceptance_reference_data/case_dijk3_2c_dp_with_default_layers/summary_costs.csv
@@ -40,7 +40,7 @@ Construction length (cost incl surtax):;0;1456.0;4213.48;17479.87;35196.38
 Total measure meters;0;0;0;0;0
 Total measure cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total measure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
-Infrastructure cost;nan;nan;nan;nan;nan;nan
-Infrastructure cost incl surtax;nan;nan;nan;nan;nan;nan
+Infrastructure cost;0.0;0.0;0.0;0.0;0.0;0.0
+Infrastructure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0

--- a/tests/test_data/acceptance_reference_data/case_dijk3_2d_dhds_with_default_layers/summary_costs.csv
+++ b/tests/test_data/acceptance_reference_data/case_dijk3_2d_dhds_with_default_layers/summary_costs.csv
@@ -40,7 +40,7 @@ Construction length (cost incl surtax):;0;1456.0;0.0;0.0;0.0
 Total measure meters;0;0;0;0;0
 Total measure cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total measure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
-Infrastructure cost;nan;nan;nan;nan;nan;nan
-Infrastructure cost incl surtax;nan;nan;nan;nan;nan;nan
+Infrastructure cost;0.0;0.0;0.0;0.0;0.0;0.0
+Infrastructure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0

--- a/tests/test_data/acceptance_reference_data/case_dijk3_2e_dhdp_with_default_layers/summary_costs.csv
+++ b/tests/test_data/acceptance_reference_data/case_dijk3_2e_dhdp_with_default_layers/summary_costs.csv
@@ -40,7 +40,7 @@ Construction length (cost incl surtax):;0;1456.0;4213.48;20175.58;39682.73
 Total measure meters;0;0;0;0;0
 Total measure cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total measure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
-Infrastructure cost;nan;nan;nan;nan;nan;nan
-Infrastructure cost incl surtax;nan;nan;nan;nan;nan;nan
+Infrastructure cost;0.0;0.0;0.0;0.0;0.0;0.0
+Infrastructure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0

--- a/tests/test_data/acceptance_reference_data/case_dijk3_2f_dsdp_with_default_layers/summary_costs.csv
+++ b/tests/test_data/acceptance_reference_data/case_dijk3_2f_dsdp_with_default_layers/summary_costs.csv
@@ -40,7 +40,7 @@ Construction length (cost incl surtax):;0;1456.0;4213.48;20175.58;39682.73
 Total measure meters;0;0;0;0;0
 Total measure cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total measure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
-Infrastructure cost;nan;nan;nan;nan;nan;nan
-Infrastructure cost incl surtax;nan;nan;nan;nan;nan;nan
+Infrastructure cost;0.0;0.0;0.0;0.0;0.0;0.0
+Infrastructure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0

--- a/tests/test_data/acceptance_reference_data/case_dijk3_2g_dhdsdp_with_default_layers/summary_costs.csv
+++ b/tests/test_data/acceptance_reference_data/case_dijk3_2g_dhdsdp_with_default_layers/summary_costs.csv
@@ -40,7 +40,7 @@ Construction length (cost incl surtax):;0;1456.0;4213.48;23543.42;44842.04
 Total measure meters;0;0;0;0;0
 Total measure cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total measure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
-Infrastructure cost;nan;nan;nan;nan;nan;nan
-Infrastructure cost incl surtax;nan;nan;nan;nan;nan;nan
+Infrastructure cost;0.0;0.0;0.0;0.0;0.0;0.0
+Infrastructure cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost;0.0;0.0;0.0;0.0;0.0;0.0
 Total cost incl surtax;0.0;0.0;0.0;0.0;0.0;0.0


### PR DESCRIPTION
## Issue addressed
Solves #171 

## Code of conduct
- [x] I HAVE NOT added sensitive or compromised (test) data to the repository.
- [x] I HAVE NOT added vulnerabilities to the repository.
- [ ] I HAVE discussed my solution with (other) members of the KOSWAT team.

## What has been done?
Calculate the infrastructure cost (excl/incl surtax) on summary level, as that is where the strategy output (selected profile per location) and infra cost per location are known.
In case no profile report or no locations for the given profile exist, `0.0` instead of `nan` is returned, which requires updating all sandbox test references.

### Checklist
- [x] Tests are either added or updated.
- [x] Branch is up to date with `master`.
- [x] Updated documentation if needed.

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
