### PR TITLE
chore: 154 update the code so that no surroundings are imported into the surroundingswrapper

### DIFF
--- a/koswat/configuration/io/csv/koswat_surroundings_csv_reader.py
+++ b/koswat/configuration/io/csv/koswat_surroundings_csv_reader.py
@@ -1,6 +1,5 @@
 import math
 import re
-from math import isclose
 from pathlib import Path
 
 from shapely import Point

--- a/koswat/cost_report/infrastructure/infrastructure_profile_costs_calculator.py
+++ b/koswat/cost_report/infrastructure/infrastructure_profile_costs_calculator.py
@@ -29,7 +29,7 @@ class InfrastructureProfileCostsCalculator:
     ) -> list[InfrastructureLocationCosts]:
         """
         Calculates the costs affecting this instance's infrastructure
-        at all points where its present.
+        at all points where it is present.
 
         Args:
             zone_a_width (float): Width of zone type `A`.

--- a/koswat/cost_report/infrastructure/multi_infrastructure_profile_costs_calculator.py
+++ b/koswat/cost_report/infrastructure/multi_infrastructure_profile_costs_calculator.py
@@ -33,7 +33,7 @@ class MultiInfrastructureProfileCostsCalculator:
     ) -> list[InfrastructureLocationProfileCostReport]:
         """
         Calculates the costs related to appyling the provided `reinforcement_profile`
-        at all the locations where an infrastructures' is present. It first determines
+        at all the locations where an infrastructure is present. It first determines
         zone `A` and `B` and then provides their widths to the inner
         infrastructure calculators (`InfrastructureProfileCostsCalculator`).
 

--- a/koswat/dike/surroundings/wrapper/base_surroundings_wrapper.py
+++ b/koswat/dike/surroundings/wrapper/base_surroundings_wrapper.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractmethod
+from abc import ABC
 
 from koswat.dike.surroundings.koswat_surroundings_protocol import (
     KoswatSurroundingsProtocol,
@@ -14,26 +14,8 @@ class BaseSurroundingsWrapper(ABC):
         Returns:
             list[KoswatSurroundingsProtocol]: Collection of surroundings to include in analysis.
         """
-        _surroundings = {
+        return {
             _prop: _value
             for _prop, _value in self.__dict__.items()
             if isinstance(_value, KoswatSurroundingsProtocol)
         }
-
-        return self._exclude_surroundings(_surroundings)
-
-    @abstractmethod
-    def _exclude_surroundings(self, surroundings_dict: dict) -> dict:
-        """
-        Method to exclude surroundings depending on the concrete class.
-
-        Args:
-            surroundings_dict (dict): Dictionary of surroundings that requires filtering.
-
-        Raises:
-            NotImplementedError: When no concrete class is implementing it.
-
-        Returns:
-            dict: Filtered dictionary.
-        """
-        raise NotImplementedError("Should be implemented in concrete class")

--- a/koswat/dike/surroundings/wrapper/infrastructure_surroundings_wrapper.py
+++ b/koswat/dike/surroundings/wrapper/infrastructure_surroundings_wrapper.py
@@ -56,8 +56,3 @@ class InfrastructureSurroundingsWrapper(BaseSurroundingsWrapper):
     roads_class_24_dikeside: SurroundingsInfrastructure = None
     roads_class_47_dikeside: SurroundingsInfrastructure = None
     roads_class_unknown_dikeside: SurroundingsInfrastructure = None
-
-    def _exclude_surroundings(self, surroundings_dict: dict) -> dict:
-        if not self.infrastructures_considered:
-            return {}
-        return surroundings_dict

--- a/koswat/dike/surroundings/wrapper/obstacle_surroundings_wrapper.py
+++ b/koswat/dike/surroundings/wrapper/obstacle_surroundings_wrapper.py
@@ -36,21 +36,6 @@ class ObstacleSurroundingsWrapper(BaseSurroundingsWrapper):
     railways_dikeside: SurroundingsObstacle = None
     waters_dikeside: SurroundingsObstacle = None
 
-    def _exclude_surroundings(self, surroundings_dict: dict) -> dict:
-        def exclude_surrounding(property_name: str):
-            surroundings_dict.pop(property_name + "_polderside", None)
-            surroundings_dict.pop(property_name + "_dikeside", None)
-
-        if not self.apply_buildings:
-            exclude_surrounding("buildings")
-
-        if not self.apply_railways:
-            exclude_surrounding("railways")
-
-        if not self.apply_waters:
-            exclude_surrounding("waters")
-        return surroundings_dict
-
     @property
     def obstacle_locations(self) -> list[PointSurroundings]:
         """

--- a/koswat/dike/surroundings/wrapper/surroundings_wrapper_builder.py
+++ b/koswat/dike/surroundings/wrapper/surroundings_wrapper_builder.py
@@ -62,10 +62,10 @@ class SurroundingsWrapperBuilder(BuilderProtocol):
             apply_railways=self.surroundings_section_fom.spoorwegen,
             apply_waters=self.surroundings_section_fom.water,
         )
-        if self.surroundings_section_fom.bebouwing:
-            _obs_wrapper.buildings_polderside.points = (
-                self._get_polderside_surroundings_from_fom("buildings_polderside")
-            )
+        # Buildings polderside should always be present to determine the location coordinates.
+        _obs_wrapper.buildings_polderside.points = (
+            self._get_polderside_surroundings_from_fom("buildings_polderside")
+        )
         if self.surroundings_section_fom.spoorwegen:
             _obs_wrapper.railways_polderside.points = (
                 self._get_polderside_surroundings_from_fom("railways_polderside")

--- a/koswat/dike/surroundings/wrapper/surroundings_wrapper_builder.py
+++ b/koswat/dike/surroundings/wrapper/surroundings_wrapper_builder.py
@@ -62,15 +62,18 @@ class SurroundingsWrapperBuilder(BuilderProtocol):
             apply_railways=self.surroundings_section_fom.spoorwegen,
             apply_waters=self.surroundings_section_fom.water,
         )
-        _obs_wrapper.buildings_polderside.points = (
-            self._get_polderside_surroundings_from_fom("buildings_polderside")
-        )
-        _obs_wrapper.railways_polderside.points = (
-            self._get_polderside_surroundings_from_fom("railways_polderside")
-        )
-        _obs_wrapper.waters_polderside.points = (
-            self._get_polderside_surroundings_from_fom("waters_polderside")
-        )
+        if self.surroundings_section_fom.bebouwing:
+            _obs_wrapper.buildings_polderside.points = (
+                self._get_polderside_surroundings_from_fom("buildings_polderside")
+            )
+        if self.surroundings_section_fom.spoorwegen:
+            _obs_wrapper.railways_polderside.points = (
+                self._get_polderside_surroundings_from_fom("railways_polderside")
+            )
+        if self.surroundings_section_fom.water:
+            _obs_wrapper.waters_polderside.points = (
+                self._get_polderside_surroundings_from_fom("waters_polderside")
+            )
 
         return _obs_wrapper
 
@@ -97,20 +100,31 @@ class SurroundingsWrapperBuilder(BuilderProtocol):
             infrastructures_considered=self.infrastructure_section_fom.infrastructuur,
             surtax_cost_factor=self.infrastructure_section_fom.opslagfactor_wegen,
             non_rising_dike_costs_factor=self.infrastructure_section_fom.infrakosten_0dh,
-            roads_class_2_polderside=self._get_polderside_surroundings_infrastructure(
-                "roads_class_2_polderside"
-            ),
-            roads_class_7_polderside=self._get_polderside_surroundings_infrastructure(
-                "roads_class_7_polderside"
-            ),
-            roads_class_24_polderside=self._get_polderside_surroundings_infrastructure(
-                "roads_class_24_polderside"
-            ),
-            roads_class_47_polderside=self._get_polderside_surroundings_infrastructure(
-                "roads_class_47_polderside"
-            ),
-            roads_class_unknown_polderside=self._get_polderside_surroundings_infrastructure(
-                "roads_class_unknown_polderside"
-            ),
         )
+        if self.infrastructure_section_fom.infrastructuur:
+            _infra_wrapper.roads_class_2_polderside = (
+                self._get_polderside_surroundings_infrastructure(
+                    "roads_class_2_polderside"
+                )
+            )
+            _infra_wrapper.roads_class_7_polderside = (
+                self._get_polderside_surroundings_infrastructure(
+                    "roads_class_7_polderside"
+                )
+            )
+            _infra_wrapper.roads_class_24_polderside = (
+                self._get_polderside_surroundings_infrastructure(
+                    "roads_class_24_polderside"
+                )
+            )
+            _infra_wrapper.roads_class_47_polderside = (
+                self._get_polderside_surroundings_infrastructure(
+                    "roads_class_47_polderside"
+                )
+            )
+            _infra_wrapper.roads_class_unknown_polderside = (
+                self._get_polderside_surroundings_infrastructure(
+                    "roads_class_unknown_polderside"
+                )
+            )
         return _infra_wrapper

--- a/tests/configuration/io/test_surroundings_wrapper_collection_importer.py
+++ b/tests/configuration/io/test_surroundings_wrapper_collection_importer.py
@@ -128,7 +128,7 @@ class TestSurroundingsWrapperCollectionImporter:
         # 2. Run test.
         _surroundings_wrapper_list = _builder.build()
 
-        # 3. Verify expectations (specific for the caes present in the test data).
+        # 3. Verify expectations (specific for the case present in the test data).
         assert len(_surroundings_wrapper_list) == 2
         for _sw in _surroundings_wrapper_list:
             assert isinstance(_sw, SurroundingsWrapper)

--- a/tests/dike/surroundings/wrapper/test_surroundings_wrapper.py
+++ b/tests/dike/surroundings/wrapper/test_surroundings_wrapper.py
@@ -1,9 +1,7 @@
 import shutil
-from typing import Callable, Iterator
+from typing import Iterator
 
 import pytest
-from numpy import isin
-from shapely.geometry import Point
 
 from koswat.configuration.io.ini.koswat_general_ini_fom import (
     InfrastructureSectionFom,


### PR DESCRIPTION
## Issue addressed
Solves #154 

## Code of conduct
- [x] I HAVE NOT added sensitive or compromised (test) data to the repository.
- [x] I HAVE NOT added vulnerabilities to the repository.
- [x] I HAVE discussed my solution with (other) members of the KOSWAT team.

## What has been done?
Instead of reading all surroundings and filtering them out in the wrappers based on the config (`surroundings_collection`), don't read them at all based on the config.

### Checklist
- [x] Tests are either added or updated.
- [x] Branch is up to date with `master`.
- [x] Updated documentation if needed.

## Additional Notes (optional)
- The setting `bebouwing` from `SurroundingsSectionFom` is ignored when reading surroundings as buildings should always be imported
- No testcase has been added `SurroundingsWrapperBuilder` as that would require too much context
