### PR TITLE
Fix: improve performance infra cost summation

### DIFF
--- a/koswat/cost_report/io/summary/summary_costs/summary_costs_csv_fom_builder.py
+++ b/koswat/cost_report/io/summary/summary_costs/summary_costs_csv_fom_builder.py
@@ -148,18 +148,20 @@ class SummaryCostsCsvFomBuilder(BuilderProtocol):
         _infrastructure_rows = defaultdict(list)
 
         # Cost per reinforcement type
+        _infra_cost_per_reinforcement = (
+            self.koswat_summary.get_infra_costs_per_reinforcement()
+        )
+
         for _ordered_reinf in self._get_summary_reinforcement_type_column_order():
             _infrastructure_rows[_infrastructure_cost_key].append(
                 round(
-                    self.koswat_summary.get_infrastructure_cost(_ordered_reinf),
+                    _infra_cost_per_reinforcement[_ordered_reinf][0],
                     self._decimals,
                 )
             )
             _infrastructure_rows[_infrastructure_cost_incl_surtax_key].append(
                 round(
-                    self.koswat_summary.get_infrastructure_cost_with_surtax(
-                        _ordered_reinf
-                    ),
+                    _infra_cost_per_reinforcement[_ordered_reinf][1],
                     self._decimals,
                 )
             )

--- a/koswat/cost_report/io/summary/summary_costs/summary_costs_csv_fom_builder.py
+++ b/koswat/cost_report/io/summary/summary_costs/summary_costs_csv_fom_builder.py
@@ -148,7 +148,7 @@ class SummaryCostsCsvFomBuilder(BuilderProtocol):
         _infrastructure_rows = defaultdict(list)
 
         # Cost per reinforcement type
-        _infra_cost_per_reinforcement = self.koswat_summary.get_infra_costs()
+        _infra_cost_per_reinforcement = self.koswat_summary.get_infrastructure_costs()
 
         for _ordered_reinf in self._get_summary_reinforcement_type_column_order():
             _infrastructure_rows[_infrastructure_cost_key].append(

--- a/koswat/cost_report/io/summary/summary_costs/summary_costs_csv_fom_builder.py
+++ b/koswat/cost_report/io/summary/summary_costs/summary_costs_csv_fom_builder.py
@@ -148,9 +148,7 @@ class SummaryCostsCsvFomBuilder(BuilderProtocol):
         _infrastructure_rows = defaultdict(list)
 
         # Cost per reinforcement type
-        _infra_cost_per_reinforcement = (
-            self.koswat_summary.get_infra_costs_per_reinforcement()
-        )
+        _infra_cost_per_reinforcement = self.koswat_summary.get_infra_costs_by_profile()
 
         for _ordered_reinf in self._get_summary_reinforcement_type_column_order():
             _infrastructure_rows[_infrastructure_cost_key].append(

--- a/koswat/cost_report/io/summary/summary_costs/summary_costs_csv_fom_builder.py
+++ b/koswat/cost_report/io/summary/summary_costs/summary_costs_csv_fom_builder.py
@@ -148,7 +148,7 @@ class SummaryCostsCsvFomBuilder(BuilderProtocol):
         _infrastructure_rows = defaultdict(list)
 
         # Cost per reinforcement type
-        _infra_cost_per_reinforcement = self.koswat_summary.get_infra_costs_by_profile()
+        _infra_cost_per_reinforcement = self.koswat_summary.get_infra_costs()
 
         for _ordered_reinf in self._get_summary_reinforcement_type_column_order():
             _infrastructure_rows[_infrastructure_cost_key].append(

--- a/koswat/cost_report/io/summary/summary_costs/summary_costs_csv_fom_builder.py
+++ b/koswat/cost_report/io/summary/summary_costs/summary_costs_csv_fom_builder.py
@@ -153,13 +153,13 @@ class SummaryCostsCsvFomBuilder(BuilderProtocol):
         for _ordered_reinf in self._get_summary_reinforcement_type_column_order():
             _infrastructure_rows[_infrastructure_cost_key].append(
                 round(
-                    _infra_cost_per_reinforcement[_ordered_reinf][0],
+                    _infra_cost_per_reinforcement.get(_ordered_reinf, (0.0, 0.0))[0],
                     self._decimals,
                 )
             )
             _infrastructure_rows[_infrastructure_cost_incl_surtax_key].append(
                 round(
-                    _infra_cost_per_reinforcement[_ordered_reinf][1],
+                    _infra_cost_per_reinforcement.get(_ordered_reinf, (0.0, 0.0))[1],
                     self._decimals,
                 )
             )

--- a/koswat/cost_report/multi_location_profile/multi_location_profile_cost_report.py
+++ b/koswat/cost_report/multi_location_profile/multi_location_profile_cost_report.py
@@ -28,11 +28,11 @@ class MultiLocationProfileCostReport(CostReportProtocol):
             dict[PointSurroundings, tuple[float, float]]: Total cost per location (without and with surtax).
         """
         return {
-            _infra_cost_report.location: (
-                _infra_cost_report.total_cost,
-                _infra_cost_report.total_cost_with_surtax,
+            _infra_costs_report.location: (
+                _infra_costs_report.total_cost,
+                _infra_costs_report.total_cost_with_surtax,
             )
-            for _infra_cost_report in self.infra_multilocation_profile_cost_report
+            for _infra_costs_report in self.infra_multilocation_profile_cost_report
         }
 
     @property

--- a/koswat/cost_report/multi_location_profile/multi_location_profile_cost_report.py
+++ b/koswat/cost_report/multi_location_profile/multi_location_profile_cost_report.py
@@ -17,16 +17,21 @@ class MultiLocationProfileCostReport(CostReportProtocol):
     ] = field(default_factory=lambda: [])
     profile_cost_report: ProfileCostReport = None
 
-    def get_infra_costs_per_location(self) -> dict[PointSurroundings, float]:
+    def get_infra_costs_per_location(
+        self,
+    ) -> dict[PointSurroundings, tuple[float, float]]:
         """
         Gets the total costs related to infrastructures at each of the points for
         the profile type in `profile_cost_report`
 
         Returns:
-            dict[PointSurroundings, float]: Total cost per location.
+            dict[PointSurroundings, tuple[float, float]]: Total cost per location (without and with surtax).
         """
         return {
-            _infra_cost_report.location: _infra_cost_report.total_cost
+            _infra_cost_report.location: (
+                _infra_cost_report.total_cost,
+                _infra_cost_report.total_cost_with_surtax,
+            )
             for _infra_cost_report in self.infra_multilocation_profile_cost_report
         }
 

--- a/koswat/cost_report/summary/koswat_summary.py
+++ b/koswat/cost_report/summary/koswat_summary.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import Type
 
 from koswat.cost_report.multi_location_profile import MultiLocationProfileCostReport
 from koswat.dike.surroundings.point.point_surroundings import PointSurroundings
@@ -24,13 +23,13 @@ class KoswatSummary:
     )
 
     def get_report_by_profile(
-        self, profile_type: Type[ReinforcementProfileProtocol]
+        self, profile_type: type[ReinforcementProfileProtocol]
     ) -> MultiLocationProfileCostReport | None:
         """
         Get the report for a specific profile type.
 
         Args:
-            profile_type (Type[ReinforcementProfileProtocol]): Type of reinforcement profile.
+            profile_type (type[ReinforcementProfileProtocol]): Type of reinforcement profile.
 
         Returns:
             MultiLocationProfileCostReport | None: Report for the profile type.
@@ -50,7 +49,7 @@ class KoswatSummary:
         self,
     ) -> dict[type[ReinforcementProfileProtocol], list[PointSurroundings]]:
         """
-        Get the locations for per selected profile type.
+        Get the locations per selected profile type.
 
         Returns:
             dict[type[ReinforcementProfileProtocol], list[PointSurroundings]]:
@@ -64,7 +63,7 @@ class KoswatSummary:
 
         return dict(_locs_per_reinforcements)
 
-    def get_infra_costs_per_reinforcement(
+    def get_infra_costs_by_profile(
         self,
     ) -> defaultdict[type[ReinforcementProfileProtocol], tuple[float, float]]:
         """
@@ -96,13 +95,13 @@ class KoswatSummary:
         return _infra_cost_per_reinforcement
 
     def get_infrastructure_cost(
-        self, profile_type: Type[ReinforcementProfileProtocol]
+        self, profile_type: type[ReinforcementProfileProtocol]
     ) -> float:
         """
         Get the infrastructure cost for those locations for which a specific profile type is selected.
 
         Args:
-            profile_type (Type[ReinforcementProfileProtocol]): Type of reinforcement profile.
+            profile_type (type[ReinforcementProfileProtocol]): Type of reinforcement profile.
 
         Returns:
             float: Infrastructure cost.
@@ -118,7 +117,7 @@ class KoswatSummary:
         )
 
     def get_infrastructure_cost_with_surtax(
-        self, profile_type: Type[ReinforcementProfileProtocol]
+        self, profile_type: type[ReinforcementProfileProtocol]
     ) -> float:
         _locations = self.get_locations_by_profile(profile_type)
         if not _locations:

--- a/koswat/cost_report/summary/koswat_summary.py
+++ b/koswat/cost_report/summary/koswat_summary.py
@@ -68,7 +68,7 @@ class KoswatSummary:
     ) -> defaultdict[type[ReinforcementProfileProtocol], tuple[float, float]]:
         """
         Gets the infrastructure costs for each profile type
-        for the locations for which the profile type is selected.
+        for those locations for which the profile type is selected.
 
         Returns:
             defaultdict[type[ReinforcementProfileProtocol], tuple[float, float]]:
@@ -77,15 +77,22 @@ class KoswatSummary:
         _locs_per_reinforcements = self.get_locations_by_profile()
 
         _infra_cost_per_reinforcement = defaultdict(lambda: (0.0, 0.0))
+        _infra_cost_list, _infra_cost_with_surtax_list = [], []
         for _rt, _locs in _locs_per_reinforcements.items():
-            _infra_cost_list, _infra_cost_with_surtax_list = zip(
-                *(
-                    (_impcr.total_cost, _impcr.total_cost_with_surtax)
-                    for _lprl in self.locations_profile_report_list
-                    for _impcr in _lprl.infra_multilocation_profile_cost_report
-                    if _impcr.location in _locs
+            for _lprl in self.locations_profile_report_list:
+                if not type(_lprl.profile_cost_report.reinforced_profile) == _rt:
+                    continue
+                if not _lprl.infra_multilocation_profile_cost_report:
+                    continue
+                _infra_cost, _infra_cost_with_surtax = zip(
+                    *(
+                        (_impcr.total_cost, _impcr.total_cost_with_surtax)
+                        for _impcr in _lprl.infra_multilocation_profile_cost_report
+                        if _impcr.location in _locs
+                    )
                 )
-            )
+                _infra_cost_list.append(sum(_infra_cost))
+                _infra_cost_with_surtax_list.append(sum(_infra_cost_with_surtax))
 
             _infra_cost_per_reinforcement[_rt] = (
                 sum(_infra_cost_list),

--- a/koswat/cost_report/summary/koswat_summary.py
+++ b/koswat/cost_report/summary/koswat_summary.py
@@ -58,13 +58,15 @@ class KoswatSummary:
         """
         _infra_cost_per_reinforcement = defaultdict(tuple)
 
-        _infra_per_reinforcement = defaultdict(list)
+        # Get the infra cost tuples (without and with surtax) for each location.
+        _infra_cost_dict = defaultdict(list)
         for _loc in self.reinforcement_per_locations:
-            _infra_per_reinforcement[_loc.selected_measure].append(
+            _infra_cost_dict[_loc.selected_measure].append(
                 _loc.get_infrastructure_costs(_loc.selected_measure)
             )
 
-        for _rt, _infra_costs in _infra_per_reinforcement.items():
+        # Sum the infra costs for each reinforcement type.
+        for _rt, _infra_costs in _infra_cost_dict.items():
             _infra_cost, _infra_cost_with_surtax = zip(*_infra_costs)
             _infra_cost_per_reinforcement[_rt] = (
                 sum(_infra_cost),
@@ -72,38 +74,3 @@ class KoswatSummary:
             )
 
         return dict(_infra_cost_per_reinforcement)
-
-    def get_infrastructure_cost(
-        self, profile_type: type[ReinforcementProfileProtocol]
-    ) -> float:
-        """
-        Get the infrastructure cost for those locations for which a specific profile type is selected.
-
-        Args:
-            profile_type (type[ReinforcementProfileProtocol]): Type of reinforcement profile.
-
-        Returns:
-            float: Infrastructure cost.
-        """
-        _locations = self.get_locations_by_profile(profile_type)
-        if not _locations:
-            return 0.0
-        _report = self.get_report_by_profile(profile_type)
-        return sum(
-            ilpcr.total_cost
-            for ilpcr in _report.infra_multilocation_profile_cost_report
-            if ilpcr.location in _locations
-        )
-
-    def get_infrastructure_cost_with_surtax(
-        self, profile_type: type[ReinforcementProfileProtocol]
-    ) -> float:
-        _locations = self.get_locations_by_profile(profile_type)
-        if not _locations:
-            return 0.0
-        _report = self.get_report_by_profile(profile_type)
-        return sum(
-            ilpcr.total_cost_with_surtax
-            for ilpcr in _report.infra_multilocation_profile_cost_report
-            if ilpcr.location in _locations
-        )

--- a/koswat/cost_report/summary/koswat_summary.py
+++ b/koswat/cost_report/summary/koswat_summary.py
@@ -44,32 +44,32 @@ class KoswatSummary:
             None,
         )
 
-    def get_infra_costs(
+    def get_infrastructure_costs(
         self,
-    ) -> defaultdict[type[ReinforcementProfileProtocol], tuple[float, float]]:
+    ) -> dict[type[ReinforcementProfileProtocol], tuple[float, float]]:
         """
         Gets the infrastructure costs for each profile type
         for those locations for which the profile type is selected.
 
         Returns:
-            defaultdict[type[ReinforcementProfileProtocol], tuple[float, float]]:
-                infra cost without and with surtax per reinforcement type.
+            dict[type[ReinforcementProfileProtocol], tuple[float, float]]:
+                infrastructure costs without and with surtax per reinforcement type.
         """
-        _infra_cost_per_reinforcement = defaultdict(tuple)
+        _infra_costs_per_reinforcement = defaultdict(tuple)
 
         # Get the infra cost tuples (without and with surtax) for each location.
-        _infra_cost_dict = defaultdict(list)
+        _infra_costs_dict = defaultdict(list)
         for _loc in self.reinforcement_per_locations:
-            _infra_cost_dict[_loc.selected_measure].append(
+            _infra_costs_dict[_loc.selected_measure].append(
                 _loc.get_infrastructure_costs(_loc.selected_measure)
             )
 
         # Sum the infra costs for each reinforcement type.
-        for _rt, _infra_costs in _infra_cost_dict.items():
-            _infra_cost, _infra_cost_with_surtax = zip(*_infra_costs)
-            _infra_cost_per_reinforcement[_rt] = (
-                sum(_infra_cost),
-                sum(_infra_cost_with_surtax),
+        for _rt, _infra_costs in _infra_costs_dict.items():
+            _infra_costs, _infra_costs_with_surtax = zip(*_infra_costs)
+            _infra_costs_per_reinforcement[_rt] = (
+                sum(_infra_costs),
+                sum(_infra_costs_with_surtax),
             )
 
-        return dict(_infra_cost_per_reinforcement)
+        return dict(_infra_costs_per_reinforcement)

--- a/koswat/cost_report/summary/koswat_summary.py
+++ b/koswat/cost_report/summary/koswat_summary.py
@@ -4,7 +4,6 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 
 from koswat.cost_report.multi_location_profile import MultiLocationProfileCostReport
-from koswat.dike.surroundings.point.point_surroundings import PointSurroundings
 from koswat.dike_reinforcements.reinforcement_profile.reinforcement_profile_protocol import (
     ReinforcementProfileProtocol,
 )
@@ -45,7 +44,7 @@ class KoswatSummary:
             None,
         )
 
-    def get_infra_costs_by_profile(
+    def get_infra_costs(
         self,
     ) -> defaultdict[type[ReinforcementProfileProtocol], tuple[float, float]]:
         """

--- a/koswat/cost_report/summary/koswat_summary_location_matrix_builder.py
+++ b/koswat/cost_report/summary/koswat_summary_location_matrix_builder.py
@@ -92,9 +92,10 @@ class KoswatSummaryLocationMatrixBuilder(BuilderProtocol):
         # Get the reinforcement cost of the first location for each reinforcement (if present).
         _reinforcement_costs = []
         for _ref_loc_dict in locations_per_reinforcement:
-            if not _ref_loc_dict.values():
+            _locs = list(_ref_loc_dict.values())
+            if not _locs:
                 continue
-            _reinforcement_costs.append(list(_ref_loc_dict.values())[0])
+            _reinforcement_costs.append(_locs[0])
 
         return list(map(get_reinforcement, _reinforcement_costs))
 

--- a/koswat/cost_report/summary/koswat_summary_location_matrix_builder.py
+++ b/koswat/cost_report/summary/koswat_summary_location_matrix_builder.py
@@ -89,6 +89,7 @@ class KoswatSummaryLocationMatrixBuilder(BuilderProtocol):
                 ground_level_surface=_reinforcement.new_ground_level_surface,
             )
 
+        # Get the reinforcement cost of the first location for each reinforcement.
         _reinforcement_costs = [
             next(iter(_reinforcement_dict.values()), None)
             for _reinforcement_dict in locations_per_reinforcement

--- a/koswat/cost_report/summary/koswat_summary_location_matrix_builder.py
+++ b/koswat/cost_report/summary/koswat_summary_location_matrix_builder.py
@@ -89,18 +89,14 @@ class KoswatSummaryLocationMatrixBuilder(BuilderProtocol):
                 ground_level_surface=_reinforcement.new_ground_level_surface,
             )
 
-        # Get the reinforcement cost of the first location for each reinforcement.
-        _reinforcement_costs = [
-            next(iter(_reinforcement_dict.values()), None)
-            for _reinforcement_dict in locations_per_reinforcement
-        ]
+        # Get the reinforcement cost of the first location for each reinforcement (if present).
+        _reinforcement_costs = []
+        for _ref_loc_dict in locations_per_reinforcement:
+            if not _ref_loc_dict.values():
+                continue
+            _reinforcement_costs.append(list(_ref_loc_dict.values())[0])
 
-        return list(
-            map(
-                get_reinforcement,
-                filter(lambda x: x is not None, _reinforcement_costs),
-            )
-        )
+        return list(map(get_reinforcement, _reinforcement_costs))
 
     def build(
         self,

--- a/koswat/cost_report/summary/koswat_summary_location_matrix_builder.py
+++ b/koswat/cost_report/summary/koswat_summary_location_matrix_builder.py
@@ -110,11 +110,13 @@ class KoswatSummaryLocationMatrixBuilder(BuilderProtocol):
                 ground_level_surface=_reinforcement.new_ground_level_surface,
             )
 
-        for _loc_key, _strat_locs in _strategy_locations_dict.items():
+        for _loc_key in _strategy_locations_dict.keys():
             for _reinforce_matrix_dict in _reinforce_matrix_dict_list:
                 # Add the reinforcement to the matrix if location exists.
                 if _loc_key in _reinforce_matrix_dict:
-                    _strat_locs.append(_reinforce_matrix_dict[_loc_key])
+                    _strategy_locations_dict[_loc_key].append(
+                        _reinforce_matrix_dict[_loc_key]
+                    )
                 else:
                     continue
                 # Add to the reinforcement to the list if not already present.

--- a/koswat/cost_report/summary/koswat_summary_location_matrix_builder.py
+++ b/koswat/cost_report/summary/koswat_summary_location_matrix_builder.py
@@ -39,14 +39,16 @@ class KoswatSummaryLocationMatrixBuilder(BuilderProtocol):
                     locations_profile.profile_cost_report.reinforced_profile
                 ),
                 base_costs=locations_profile.profile_cost_report.total_cost,
+                base_costs_with_surtax=locations_profile.profile_cost_report.total_cost_with_surtax,
                 ground_level_surface=locations_profile.profile_cost_report.reinforced_profile.new_ground_level_surface,
             )
 
         _dict_matrix = defaultdict(create_strategy_location_reinforcement_costs)
         for _location in locations_profile.report_locations:
-            _dict_matrix[_location].infrastructure_costs = _infra_costs.get(
-                _location, 0.0
-            )
+            (
+                _dict_matrix[_location].infrastructure_costs,
+                _dict_matrix[_location].infrastructure_costs_with_surtax,
+            ) = _infra_costs.get(_location, (0.0, 0.0))
         return dict(_dict_matrix)
 
     def _get_list_summary_matrix_for_locations_with_reinforcements(

--- a/koswat/cost_report/summary/koswat_summary_location_matrix_builder.py
+++ b/koswat/cost_report/summary/koswat_summary_location_matrix_builder.py
@@ -90,14 +90,14 @@ class KoswatSummaryLocationMatrixBuilder(BuilderProtocol):
             )
 
         _reinforcement_costs = [
-            next(iter(_reinforcement_dict.values()))
+            next(iter(_reinforcement_dict.values()), None)
             for _reinforcement_dict in locations_per_reinforcement
         ]
 
         return list(
             map(
                 get_reinforcement,
-                _reinforcement_costs,
+                filter(lambda x: x is not None, _reinforcement_costs),
             )
         )
 

--- a/koswat/strategies/README.md
+++ b/koswat/strategies/README.md
@@ -10,7 +10,7 @@ This modules contains the logic to choose which measure will be applied for a gi
 
 - `StrategyLocationInput`, gathers all the input required for a strategy to determine which reinforcement can be applied based on its location (`point_surrounding`) and `available_reinforcements`.
     - point_surrounding (`PointSurroundings`), a point (meter) in the dike traject.
-    - strategy_reinforcement (`list[StrategyReinforcementInput]`), all the reinforcements that can be used at this location and their related cost and width.
+    - strategy_reinforcement_type_costs (`list[StrategyReinforcementTypeCosts]`), all the reinforcements that can be used at this location and their related cost.
     - cheapest_reinforcement (`StrategyReinforcementTypeCosts`), returns which "available reinforcment" has the lower total costs at this location.
     - available_measures (`Type[ReinforcementProfileProtocol]`), returns only the reinforcement type from the `strategy_reinforcement_type_costs` collection.
 

--- a/koswat/strategies/strategy_location_input.py
+++ b/koswat/strategies/strategy_location_input.py
@@ -49,3 +49,16 @@ class StrategyLocationInput:
         raise ValueError(
             f"Reinforcement {reinforcement_type.output_name} not available, costs cannot be computed."
         )
+
+    def get_infrastructure_costs(
+        self, reinforcement_type: type[ReinforcementProfileProtocol]
+    ) -> tuple[float, float]:
+        for _srtc in self.strategy_reinforcement_type_costs:
+            if _srtc.reinforcement_type == reinforcement_type:
+                return (
+                    _srtc.infrastructure_costs,
+                    _srtc.infrastructure_costs_with_surtax,
+                )
+        raise ValueError(
+            f"Reinforcement {reinforcement_type.output_name} not available, costs cannot be computed."
+        )

--- a/koswat/strategies/strategy_location_input.py
+++ b/koswat/strategies/strategy_location_input.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass, field
-from typing import Type
 
 from koswat.dike.surroundings.point.point_surroundings import PointSurroundings
 from koswat.dike_reinforcements.reinforcement_profile.reinforcement_profile_protocol import (
@@ -28,7 +27,7 @@ class StrategyLocationInput:
         return min(self.strategy_reinforcement_type_costs, key=lambda x: x.total_costs)
 
     @property
-    def available_measures(self) -> list[Type[ReinforcementProfileProtocol]]:
+    def available_measures(self) -> list[type[ReinforcementProfileProtocol]]:
         """
         Gets all the available reinforcement types in `strategy_location_reinforcements`.
         It is called `available_measures` to match the `StrategyLocationReinforcement`

--- a/koswat/strategies/strategy_location_input.py
+++ b/koswat/strategies/strategy_location_input.py
@@ -20,7 +20,8 @@ class StrategyLocationInput:
     @property
     def cheapest_reinforcement(self) -> StrategyReinforcementTypeCosts:
         """
-        Gets the `StrategyLocationReinforcementCosts` with the lower `total_costs` value.
+        Gets the `StrategyLocationReinforcementCosts` with the lowest `total_costs` value.
+
         Returns:
             StrategyLocationReinforcementCosts: The cheapest reinforcement for this location.
         """
@@ -43,6 +44,18 @@ class StrategyLocationInput:
     def get_reinforcement_costs(
         self, reinforcement_type: type[ReinforcementProfileProtocol]
     ) -> float:
+        """
+        Get the costs for the given reinforcement type.
+
+        Args:
+            reinforcement_type (type[ReinforcementProfileProtocol]): The reinforcement type.
+
+        Raises:
+            ValueError: The reinforcement type is not available.
+
+        Returns:
+            float: The reinforcement costs.
+        """
         for _srtc in self.strategy_reinforcement_type_costs:
             if _srtc.reinforcement_type == reinforcement_type:
                 return _srtc.total_costs
@@ -53,6 +66,18 @@ class StrategyLocationInput:
     def get_infrastructure_costs(
         self, reinforcement_type: type[ReinforcementProfileProtocol]
     ) -> tuple[float, float]:
+        """
+        Get the infrastructure costs for the given reinforcement type.
+
+        Args:
+            reinforcement_type (type[ReinforcementProfileProtocol]): The reinforcement type.
+
+        Raises:
+            ValueError: The reinforcement type is not available.
+
+        Returns:
+            tuple[float, float]: Tuple containing the infrastructure costs without and with surtax.
+        """
         for _srtc in self.strategy_reinforcement_type_costs:
             if _srtc.reinforcement_type == reinforcement_type:
                 return (

--- a/koswat/strategies/strategy_location_reinforcement.py
+++ b/koswat/strategies/strategy_location_reinforcement.py
@@ -35,8 +35,19 @@ class StrategyLocationReinforcement:
     def get_reinforcement_costs(
         self, reinforcement_type: type[ReinforcementProfileProtocol]
     ) -> float:
+        if not self.strategy_location_input:
+            return 0.0
         if reinforcement_type not in self.available_measures:
             raise ValueError(
                 f"Reinforcement {reinforcement_type.output_name} not available, costs cannot be computed.",
             )
         return self.strategy_location_input.get_reinforcement_costs(reinforcement_type)
+
+    def get_infrastructure_costs(
+        self, reinforcement_type: type[ReinforcementProfileProtocol]
+    ) -> tuple[float, float]:
+        if not self.strategy_location_input:
+            return (0.0, 0.0)
+        if reinforcement_type not in self.available_measures:
+            return (0.0, 0.0)
+        return self.strategy_location_input.get_infrastructure_costs(reinforcement_type)

--- a/koswat/strategies/strategy_location_reinforcement.py
+++ b/koswat/strategies/strategy_location_reinforcement.py
@@ -35,8 +35,6 @@ class StrategyLocationReinforcement:
     def get_reinforcement_costs(
         self, reinforcement_type: type[ReinforcementProfileProtocol]
     ) -> float:
-        if not self.strategy_location_input:
-            return 0.0
         if reinforcement_type not in self.available_measures:
             raise ValueError(
                 f"Reinforcement {reinforcement_type.output_name} not available, costs cannot be computed.",
@@ -46,8 +44,18 @@ class StrategyLocationReinforcement:
     def get_infrastructure_costs(
         self, reinforcement_type: type[ReinforcementProfileProtocol]
     ) -> tuple[float, float]:
-        if not self.strategy_location_input:
-            return (0.0, 0.0)
-        if reinforcement_type not in self.available_measures:
+        """
+        Returns the infrastructure costs for the given reinforcement type (without and with surtax).
+
+        Args:
+            reinforcement_type (type[ReinforcementProfileProtocol]): Reinforcement type.
+
+        Returns:
+            tuple[float, float]: Tuple containing the infrastructure costs without and with surtax.
+        """
+        if (
+            not self.strategy_location_input
+            or reinforcement_type not in self.available_measures
+        ):
             return (0.0, 0.0)
         return self.strategy_location_input.get_infrastructure_costs(reinforcement_type)

--- a/koswat/strategies/strategy_location_reinforcement.py
+++ b/koswat/strategies/strategy_location_reinforcement.py
@@ -54,8 +54,10 @@ class StrategyLocationReinforcement:
             tuple[float, float]: Tuple containing the infrastructure costs without and with surtax.
         """
         if (
-            not self.strategy_location_input
-            or reinforcement_type not in self.available_measures
+            self.strategy_location_input
+            and reinforcement_type in self.available_measures
         ):
-            return (0.0, 0.0)
-        return self.strategy_location_input.get_infrastructure_costs(reinforcement_type)
+            return self.strategy_location_input.get_infrastructure_costs(
+                reinforcement_type
+            )
+        return (0.0, 0.0)

--- a/koswat/strategies/strategy_reinforcement_type_costs.py
+++ b/koswat/strategies/strategy_reinforcement_type_costs.py
@@ -10,7 +10,9 @@ from koswat.dike_reinforcements.reinforcement_profile.reinforcement_profile_prot
 class StrategyReinforcementTypeCosts:
     reinforcement_type: Type[ReinforcementProfileProtocol]
     base_costs: float = 0.0
+    base_costs_with_surtax: float = 0.0  # Not needed yet
     infrastructure_costs: float = 0.0
+    infrastructure_costs_with_surtax: float = 0.0
     ground_level_surface: float = 0.0
 
     @property

--- a/koswat/strategies/strategy_reinforcement_type_costs.py
+++ b/koswat/strategies/strategy_reinforcement_type_costs.py
@@ -9,7 +9,8 @@ from koswat.dike_reinforcements.reinforcement_profile.reinforcement_profile_prot
 class StrategyReinforcementTypeCosts:
     reinforcement_type: type[ReinforcementProfileProtocol]
     base_costs: float = 0.0
-    base_costs_with_surtax: float = 0.0  # Not needed yet
+    # Not needed yet
+    base_costs_with_surtax: float = 0.0
     infrastructure_costs: float = 0.0
     infrastructure_costs_with_surtax: float = 0.0
 

--- a/tests/cost_report/io/summary/conftest.py
+++ b/tests/cost_report/io/summary/conftest.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import Callable, Iterable, Type
+from typing import Callable, Iterable
 
 import pytest
 from shapely.geometry import Point
@@ -25,16 +25,15 @@ from koswat.dike.surroundings.point.point_surroundings import PointSurroundings
 from koswat.dike.surroundings.surroundings_infrastructure import (
     SurroundingsInfrastructure,
 )
-from koswat.dike_reinforcements.reinforcement_profile.outside_slope import (
+from koswat.dike_reinforcements.reinforcement_profile import (
     CofferdamReinforcementProfile,
-)
-from koswat.dike_reinforcements.reinforcement_profile.reinforcement_profile_protocol import (
-    ReinforcementProfileProtocol,
-)
-from koswat.dike_reinforcements.reinforcement_profile.standard import (
     PipingWallReinforcementProfile,
     SoilReinforcementProfile,
     StabilityWallReinforcementProfile,
+    VPSReinforcementProfile,
+)
+from koswat.dike_reinforcements.reinforcement_profile.reinforcement_profile_protocol import (
+    ReinforcementProfileProtocol,
 )
 from koswat.strategies.strategy_location_reinforcement import (
     StrategyLocationReinforcement,
@@ -94,7 +93,7 @@ def _create_infra_reports(
 
 
 def _create_report(
-    report_type: Type[ReinforcementProfileProtocol],
+    report_type: type[ReinforcementProfileProtocol],
     available_points: list[PointSurroundings],
     selected_locations: int,
 ) -> MultiLocationProfileCostReport:
@@ -164,6 +163,7 @@ def _get_valid_mocked_summary_fixture() -> KoswatSummary:
         PipingWallReinforcementProfile,
         SoilReinforcementProfile,
         StabilityWallReinforcementProfile,
+        # VPSReinforcementProfile,
     ]
     _available_points = _create_locations()
     _summary = KoswatSummary()
@@ -186,6 +186,7 @@ def _get_valid_clusters_mocked_summary_fixture() -> KoswatSummary:
         PipingWallReinforcementProfile,
         SoilReinforcementProfile,
         StabilityWallReinforcementProfile,
+        # VPSReinforcementProfile,
     ]
     _available_points = _create_locations()
     _summary = KoswatSummary()
@@ -204,7 +205,7 @@ def _get_valid_clusters_mocked_summary_fixture() -> KoswatSummary:
 @pytest.fixture(name="cluster_shp_fom_factory")
 def _get_cluster_shp_fom_factory() -> Iterable[
     Callable[
-        [list[tuple[float, float]], Type[ReinforcementProfileProtocol], float],
+        [list[tuple[float, float]], type[ReinforcementProfileProtocol], float],
         ClusterShpFom,
     ]
 ]:
@@ -220,7 +221,7 @@ def _get_cluster_shp_fom_factory() -> Iterable[
 
     def create_cluster(
         points: list[tuple[float, float]],
-        type_reinforcement: Type[ReinforcementProfileProtocol],
+        type_reinforcement: type[ReinforcementProfileProtocol],
         new_width: float,
     ) -> ClusterShpFom:
         _tr = type_reinforcement()

--- a/tests/cost_report/io/summary/conftest.py
+++ b/tests/cost_report/io/summary/conftest.py
@@ -163,7 +163,6 @@ def _get_valid_mocked_summary_fixture() -> KoswatSummary:
         PipingWallReinforcementProfile,
         SoilReinforcementProfile,
         StabilityWallReinforcementProfile,
-        # VPSReinforcementProfile,
     ]
     _available_points = _create_locations()
     _summary = KoswatSummary()
@@ -186,7 +185,6 @@ def _get_valid_clusters_mocked_summary_fixture() -> KoswatSummary:
         PipingWallReinforcementProfile,
         SoilReinforcementProfile,
         StabilityWallReinforcementProfile,
-        # VPSReinforcementProfile,
     ]
     _available_points = _create_locations()
     _summary = KoswatSummary()

--- a/tests/cost_report/io/summary/summary_costs/test_summary_costs_csv_exporter.py
+++ b/tests/cost_report/io/summary/summary_costs/test_summary_costs_csv_exporter.py
@@ -73,8 +73,8 @@ Construction length (cost incl surtax):;0.0;0.0;0.0;0.0
 Total measure meters;0;1;1;2
 Total measure cost;0.0;8.14;16.29;48.87;73.3
 Total measure cost incl surtax;0.0;12.22;24.43;73.3;109.95
-Infrastructure cost;0.0;0.0;6.6;33.0;39.6
-Infrastructure cost incl surtax;0.0;0.0;19.8;257.4;277.2
-Total cost;0.0;8.14;22.89;81.87;112.9
-Total cost incl surtax;0.0;12.22;44.23;330.7;387.15"""
+Infrastructure cost;0.0;0.0;6.6;39.6;46.2
+Infrastructure cost incl surtax;0.0;0.0;19.8;277.2;297.0
+Total cost;0.0;8.14;22.89;88.47;119.5
+Total cost incl surtax;0.0;12.22;44.23;350.5;406.95"""
         assert _expected_text == _read_text

--- a/tests/cost_report/io/summary/summary_costs/test_summary_costs_csv_exporter.py
+++ b/tests/cost_report/io/summary/summary_costs/test_summary_costs_csv_exporter.py
@@ -73,8 +73,8 @@ Construction length (cost incl surtax):;0.0;0.0;0.0;0.0
 Total measure meters;0;1;1;2
 Total measure cost;0.0;8.14;16.29;48.87;73.3
 Total measure cost incl surtax;0.0;12.22;24.43;73.3;109.95
-Infrastructure cost;0.0;0.0;6.6;39.6;46.2
-Infrastructure cost incl surtax;0.0;0.0;19.8;277.2;297.0
-Total cost;0.0;8.14;22.89;88.47;119.5
-Total cost incl surtax;0.0;12.22;44.23;350.5;406.95"""
+Infrastructure cost;0.0;0.0;0.0;0.0;0.0
+Infrastructure cost incl surtax;0.0;0.0;0.0;0.0;0.0
+Total cost;0.0;8.14;16.29;48.87;73.3
+Total cost incl surtax;0.0;12.22;24.43;73.3;109.95"""
         assert _expected_text == _read_text

--- a/tests/strategies/conftest.py
+++ b/tests/strategies/conftest.py
@@ -43,11 +43,11 @@ def _get_example_strategy_input() -> Iterator[StrategyInput]:
     _levels_data = [
         StrategyReinforcementTypeCosts(
             reinforcement_type=_reinforcement,
-            base_costs=(10**_idx) * 42,
+            base_costs=(10**_idx) * 42.0,
             infrastructure_costs=(10 ** (len(_reinforcement_type_default_order) - 1))
-            * 42
+            * 42.0
             if _idx in [0, 1, 3]
-            else 0,  # Dramatic infra costs so they move to where we want
+            else 0.0,  # Dramatic infra costs so they move to where we want
         )
         for _idx, _reinforcement in enumerate(_reinforcement_type_default_order)
     ]
@@ -68,7 +68,7 @@ def _get_example_strategy_input() -> Iterator[StrategyInput]:
         StrategyReinforcementInput(
             reinforcement_type=_rtc.reinforcement_type,
             base_costs=_rtc.base_costs,
-            ground_level_surface=10 * (len(_reinforcement_type_default_order) - _idx),
+            ground_level_surface=10.0 * (len(_reinforcement_type_default_order) - _idx),
         )
         for _idx, _rtc in enumerate(_levels_data)
     ]

--- a/tests/strategies/conftest.py
+++ b/tests/strategies/conftest.py
@@ -81,6 +81,36 @@ def _get_example_strategy_input() -> Iterator[StrategyInput]:
     )
 
 
+@pytest.fixture(name="example_location_input")
+def _get_example_location_input(
+    example_strategy_input: StrategyInput,
+) -> Iterator[list[StrategyLocationInput]]:
+    assert any(example_strategy_input.strategy_locations)
+    assert (
+        len(
+            example_strategy_input.strategy_locations[
+                0
+            ].strategy_reinforcement_type_costs
+        )
+        == 5
+    )
+    assert (
+        len(
+            example_strategy_input.strategy_locations[
+                -1
+            ].strategy_reinforcement_type_costs
+        )
+        == 1
+    )
+    assert (
+        example_strategy_input.strategy_locations[-1]
+        .strategy_reinforcement_type_costs[0]
+        .reinforcement_type
+        != SoilReinforcementProfile
+    )
+    yield example_strategy_input.strategy_locations
+
+
 @pytest.fixture(name="example_location_reinforcements_with_buffering")
 def _get_example_location_reinforcements_with_buffering(
     example_strategy_input: StrategyInput,

--- a/tests/strategies/test_strategy_location_input.py
+++ b/tests/strategies/test_strategy_location_input.py
@@ -3,40 +3,39 @@ import pytest
 from koswat.dike_reinforcements.reinforcement_profile.standard.soil_reinforcement_profile import (
     SoilReinforcementProfile,
 )
-from koswat.strategies.strategy_input import StrategyInput
+from koswat.strategies.strategy_location_input import StrategyLocationInput
 from koswat.strategies.strategy_reinforcement_type_costs import (
     StrategyReinforcementTypeCosts,
 )
 
 
 class TestStrategyLocationInput:
-    def test_cheapest_reinforcement(self, example_strategy_input: StrategyInput):
-        # 1. Define test data.
-        _location_input = example_strategy_input.strategy_locations[0]
+    def test_cheapest_reinforcement(
+        self, example_location_input: list[StrategyLocationInput]
+    ):
+        # 1. Run test.
+        _cheapest = example_location_input[0].cheapest_reinforcement
 
-        # 2. Run test.
-        _cheapest = _location_input.cheapest_reinforcement
-
-        # 3. Verify the final expectations.
+        # 2. Verify the final expectations.
         assert _cheapest is not None
         assert isinstance(_cheapest, StrategyReinforcementTypeCosts)
 
-    def test_available_measures(self, example_strategy_input: StrategyInput):
-        # 1. Define test data.
-        _location_input = example_strategy_input.strategy_locations[0]
+    def test_available_measures(
+        self, example_location_input: list[StrategyLocationInput]
+    ):
+        # 1. Run test.
+        _available = example_location_input[0].available_measures
 
-        # 2. Run test.
-        _available = _location_input.available_measures
-
-        # 3. Verify the final expectations.
-        assert _available is not None
+        # 2. Verify the final expectations.
         assert isinstance(_available, list)
-        assert len(_available) > 0
+        assert any(_available)
         assert isinstance(_available[0], type)
 
-    def test_get_reinforcement_costs(self, example_strategy_input: StrategyInput):
+    def test_get_reinforcement_costs(
+        self, example_location_input: list[StrategyLocationInput]
+    ):
         # 1. Define test data.
-        _location_input = example_strategy_input.strategy_locations[0]
+        _location_input = example_location_input[0]
         _reinforcement_type = _location_input.available_measures[0]
 
         # 2. Run test.
@@ -49,24 +48,25 @@ class TestStrategyLocationInput:
         assert isinstance(_reinforcement_cost, float)
 
     def test_get_reinforcement_costs_raises_value_error(
-        self, example_strategy_input: StrategyInput
+        self, example_location_input: list[StrategyLocationInput]
     ):
         # 1. Define test data.
-        _location_input = example_strategy_input.strategy_locations[-1]
         _reinforcement_type = SoilReinforcementProfile
 
         # 2. Run test.
         with pytest.raises(ValueError) as exc_err:
-            _location_input.get_reinforcement_costs(_reinforcement_type)
+            example_location_input[-1].get_reinforcement_costs(_reinforcement_type)
 
         # 3. Verify the final expectations.
         assert str(exc_err.value) == (
             f"Reinforcement {_reinforcement_type.output_name} not available, costs cannot be computed."
         )
 
-    def test_get_infrastructure_costs(self, example_strategy_input: StrategyInput):
+    def test_get_infrastructure_costs(
+        self, example_location_input: list[StrategyLocationInput]
+    ):
         # 1. Define test data.
-        _location_input = example_strategy_input.strategy_locations[0]
+        _location_input = example_location_input[0]
         _reinforcement_type = _location_input.available_measures[0]
 
         # 2. Run test.
@@ -77,15 +77,16 @@ class TestStrategyLocationInput:
         assert isinstance(_infra_costs, tuple)
 
     def test_get_infrastructure_costs_raises_value_error(
-        self, example_strategy_input: StrategyInput
+        self, example_location_input: list[StrategyLocationInput]
     ):
         # 1. Define test data.
-        _location_input = example_strategy_input.strategy_locations[-1]
         _reinforcement_type = SoilReinforcementProfile
 
         # 2. Run test.
         with pytest.raises(ValueError) as exc_err:
-            _infra_costs = _location_input.get_infrastructure_costs(_reinforcement_type)
+            _infra_costs = example_location_input[-1].get_infrastructure_costs(
+                _reinforcement_type
+            )
 
         # 3. Verify the final expectations.
         assert str(exc_err.value) == (

--- a/tests/strategies/test_strategy_location_input.py
+++ b/tests/strategies/test_strategy_location_input.py
@@ -1,0 +1,93 @@
+import pytest
+
+from koswat.dike_reinforcements.reinforcement_profile.standard.soil_reinforcement_profile import (
+    SoilReinforcementProfile,
+)
+from koswat.strategies.strategy_input import StrategyInput
+from koswat.strategies.strategy_reinforcement_type_costs import (
+    StrategyReinforcementTypeCosts,
+)
+
+
+class TestStrategyLocationInput:
+    def test_cheapest_reinforcement(self, example_strategy_input: StrategyInput):
+        # 1. Define test data.
+        _location_input = example_strategy_input.strategy_locations[0]
+
+        # 2. Run test.
+        _cheapest = _location_input.cheapest_reinforcement
+
+        # 3. Verify the final expectations.
+        assert _cheapest is not None
+        assert isinstance(_cheapest, StrategyReinforcementTypeCosts)
+
+    def test_available_measures(self, example_strategy_input: StrategyInput):
+        # 1. Define test data.
+        _location_input = example_strategy_input.strategy_locations[0]
+
+        # 2. Run test.
+        _available = _location_input.available_measures
+
+        # 3. Verify the final expectations.
+        assert _available is not None
+        assert isinstance(_available, list)
+        assert len(_available) > 0
+        assert isinstance(_available[0], type)
+
+    def test_get_reinforcement_costs(self, example_strategy_input: StrategyInput):
+        # 1. Define test data.
+        _location_input = example_strategy_input.strategy_locations[0]
+        _reinforcement_type = _location_input.available_measures[0]
+
+        # 2. Run test.
+        _reinforcement_cost = _location_input.get_reinforcement_costs(
+            _reinforcement_type
+        )
+
+        # 3. Verify the final expectations.
+        assert _reinforcement_cost is not None
+        assert isinstance(_reinforcement_cost, float)
+
+    def test_get_reinforcement_costs_raises_value_error(
+        self, example_strategy_input: StrategyInput
+    ):
+        # 1. Define test data.
+        _location_input = example_strategy_input.strategy_locations[-1]
+        _reinforcement_type = SoilReinforcementProfile
+
+        # 2. Run test.
+        with pytest.raises(ValueError) as exc_err:
+            _location_input.get_reinforcement_costs(_reinforcement_type)
+
+        # 3. Verify the final expectations.
+        assert str(exc_err.value) == (
+            f"Reinforcement {_reinforcement_type.output_name} not available, costs cannot be computed."
+        )
+
+    def test_get_infrastructure_costs(self, example_strategy_input: StrategyInput):
+        # 1. Define test data.
+        _location_input = example_strategy_input.strategy_locations[0]
+        _reinforcement_type = _location_input.available_measures[0]
+
+        # 2. Run test.
+        _infra_costs = _location_input.get_infrastructure_costs(_reinforcement_type)
+
+        # 3. Verify the final expectations.
+        assert _infra_costs is not None
+        assert isinstance(_infra_costs, tuple)
+
+    def test_get_infrastructure_costs_raises_value_error(
+        self, example_strategy_input: StrategyInput
+    ):
+        # 1. Define test data.
+        _location_input = example_strategy_input.strategy_locations[-1]
+        _reinforcement_type = SoilReinforcementProfile
+
+        # 2. Run test.
+        with pytest.raises(ValueError) as exc_err:
+            _infra_costs = _location_input.get_infrastructure_costs(_reinforcement_type)
+
+        # 3. Verify the final expectations.
+        assert str(exc_err.value) == (
+            f"Reinforcement {_reinforcement_type.output_name} not available, costs cannot be computed."
+        )


### PR DESCRIPTION
## Issue addressed
Solves #203

## Code of conduct
- [x] I HAVE NOT added sensitive or compromised (test) data to the repository.
- [x] I HAVE NOT added vulnerabilities to the repository.
- [x] I HAVE discussed my solution with (other) members of the KOSWAT team.

## What has been done?
Solving performance issue caused by #171:
- Instead of looping over all locations to get the infra cost per reinforcement type for both cost without and with surtax, just loop once and get the cost without and with surtax for the relevant reinforcement types.
- Get the infra cost from `KoswatSummary.reinforcement_per_locations` instead of `KoswatSummary.locations_profile_report_list` to avoid additional looping.
  - For this the `infra_cost_with_surtax` has been added to `StrategyReinforcementTypeCosts`.

Solving performance issue caused by #202:
- Fixed a major performance bug in `KoswatSummaryLocationMatrixBuilder`.

### Checklist
- [x] Tests are either added or updated.
- [x] Branch is up to date with `master`.
- [x] Updated documentation if needed.

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
