### PR TITLE
chore: 168 reduced size of objects by removing unused infrastructure objects

### DIFF
--- a/koswat/cost_report/infrastructure/infrastructure_location_costs.py
+++ b/koswat/cost_report/infrastructure/infrastructure_location_costs.py
@@ -2,9 +2,6 @@ import math
 from dataclasses import dataclass
 
 from koswat.dike.surroundings.point.point_surroundings import PointSurroundings
-from koswat.dike.surroundings.surroundings_infrastructure import (
-    SurroundingsInfrastructure,
-)
 
 
 @dataclass
@@ -16,7 +13,6 @@ class InfrastructureLocationCosts:
     `ProfileZoneCalculator`.
     """
 
-    infrastructure: SurroundingsInfrastructure = None
     location: PointSurroundings = None
     zone_a: float = 0
     zone_a_costs: float = 0

--- a/koswat/cost_report/infrastructure/infrastructure_location_profile_cost_report.py
+++ b/koswat/cost_report/infrastructure/infrastructure_location_profile_cost_report.py
@@ -5,9 +5,6 @@ from koswat.cost_report.infrastructure.infrastructure_location_costs import (
     InfrastructureLocationCosts,
 )
 from koswat.dike.surroundings.point.point_surroundings import PointSurroundings
-from koswat.dike.surroundings.surroundings_infrastructure import (
-    SurroundingsInfrastructure,
-)
 from koswat.dike_reinforcements.reinforcement_profile.reinforcement_profile_protocol import (
     ReinforcementProfileProtocol,
 )
@@ -17,7 +14,7 @@ from koswat.dike_reinforcements.reinforcement_profile.reinforcement_profile_prot
 class InfrastructureLocationProfileCostReport(CostReportProtocol):
     # Report classifiers.
     reinforced_profile: ReinforcementProfileProtocol
-    infrastructure: SurroundingsInfrastructure
+    infrastructure_name: str
 
     # Report calculated properties.
     infrastructure_location_costs: InfrastructureLocationCosts

--- a/koswat/cost_report/infrastructure/infrastructure_profile_costs_calculator.py
+++ b/koswat/cost_report/infrastructure/infrastructure_profile_costs_calculator.py
@@ -62,7 +62,6 @@ class InfrastructureProfileCostsCalculator:
         _surface_zone_b = _total_zone_b * self.infrastructure.infrastructure_width
 
         return InfrastructureLocationCosts(
-            infrastructure=self.infrastructure,
             location=location,
             surtax=self.surtax,
             zone_a=_surface_zone_a,

--- a/koswat/cost_report/infrastructure/multi_infrastructure_profile_costs_calculator.py
+++ b/koswat/cost_report/infrastructure/multi_infrastructure_profile_costs_calculator.py
@@ -54,7 +54,7 @@ class MultiInfrastructureProfileCostsCalculator:
                 [
                     InfrastructureLocationProfileCostReport(
                         reinforced_profile=reinforced_profile,
-                        infrastructure=_calculator.infrastructure,
+                        infrastructure_name=_calculator.infrastructure.infrastructure_name,
                         infrastructure_location_costs=_subreport,
                     )
                     for _subreport in _subreports

--- a/koswat/cost_report/io/summary/summary_infrastructure_costs/summary_infrastructure_costs_csv_fom_builder.py
+++ b/koswat/cost_report/io/summary/summary_infrastructure_costs/summary_infrastructure_costs_csv_fom_builder.py
@@ -33,7 +33,7 @@ class SummaryInfrastructureCostsCsvFomBuilder(BuilderProtocol):
         self._ordered_infra_types = sorted(
             list(
                 set(
-                    _ilpcr.infrastructure.infrastructure_name
+                    _ilpcr.infrastructure_name
                     for _ilpcr in self.koswat_summary.locations_profile_report_list[
                         0
                     ].infra_multilocation_profile_cost_report
@@ -139,7 +139,7 @@ class SummaryInfrastructureCostsCsvFomBuilder(BuilderProtocol):
                 update_infra_location_cost_dict(
                     _ilpcr.infrastructure_location_costs.location,
                     _lpr.profile_type_name,
-                    _ilpcr.infrastructure.infrastructure_name,
+                    _ilpcr.infrastructure_name,
                     _ilpcr.infrastructure_location_costs,
                 )
 

--- a/koswat/dike/surroundings/wrapper/base_surroundings_wrapper.py
+++ b/koswat/dike/surroundings/wrapper/base_surroundings_wrapper.py
@@ -12,7 +12,7 @@ class BaseSurroundingsWrapper(ABC):
         The collection of `KoswatSurroundingsProtocol` objects that are considered for a scenario analysis.
 
         Returns:
-            list[KoswatSurroundingsProtocol]: Collection of surroundings to include in analysis.
+            dict[str, KoswatSurroundingsProtocol]: Collection of surroundings to include in analysis.
         """
         return {
             _prop: _value

--- a/tests/cost_report/infrastructure/test_infrastructure_location_costs.py
+++ b/tests/cost_report/infrastructure/test_infrastructure_location_costs.py
@@ -10,7 +10,6 @@ class TestInfrastructureLocationCosts:
 
         # 2. Verify expectations.
         assert isinstance(_infra_location_costs, InfrastructureLocationCosts)
-        assert not _infra_location_costs.infrastructure
         assert not _infra_location_costs.location
 
         # Verify default values are not `math.nan``.

--- a/tests/cost_report/infrastructure/test_infrastructure_location_profile_cost_report.py
+++ b/tests/cost_report/infrastructure/test_infrastructure_location_profile_cost_report.py
@@ -9,7 +9,7 @@ class TestInfrastructureLocationProfileCostReport:
         # 1. Define test data.
         _report = InfrastructureLocationProfileCostReport(
             reinforced_profile=None,
-            infrastructure=None,
+            infrastructure_name=None,
             infrastructure_location_costs=None,
         )
 

--- a/tests/cost_report/io/summary/conftest.py
+++ b/tests/cost_report/io/summary/conftest.py
@@ -22,9 +22,6 @@ from koswat.dike.characteristic_points.characteristic_points import Characterist
 from koswat.dike.koswat_profile_protocol import KoswatProfileProtocol
 from koswat.dike.profile.koswat_profile import KoswatProfileBase
 from koswat.dike.surroundings.point.point_surroundings import PointSurroundings
-from koswat.dike.surroundings.surroundings_infrastructure import (
-    SurroundingsInfrastructure,
-)
 from koswat.dike_reinforcements.reinforcement_profile import (
     CofferdamReinforcementProfile,
     PipingWallReinforcementProfile,
@@ -72,7 +69,7 @@ def _create_infra_reports(
     for i, _point in enumerate(available_points):
         _infra_report1 = InfrastructureLocationProfileCostReport(
             reinforced_profile=reinforced_profile,
-            infrastructure=SurroundingsInfrastructure(infrastructure_name="TestInfra1"),
+            infrastructure_name="TestInfra1",
             infrastructure_location_costs=InfrastructureLocationCosts(
                 location=_point,
                 zone_a=i,
@@ -84,9 +81,7 @@ def _create_infra_reports(
         )
         _infra_reports.append(_infra_report1)
         _infra_report2 = deepcopy(_infra_report1)
-        _infra_report2.infrastructure = SurroundingsInfrastructure(
-            infrastructure_name="TestInfra2"
-        )
+        _infra_report2.infrastructure_name = "TestInfra2"
         _infra_reports.append(_infra_report2)
     return _infra_reports
 
@@ -96,7 +91,7 @@ def _create_report(
     available_points: list[PointSurroundings],
     selected_locations: int,
 ) -> MultiLocationProfileCostReport:
-    def _get_layer(material: str, quantity: float) -> MockLayerReport:
+    def _get_layer(material: str) -> MockLayerReport:
         _layer_report = MockLayerReport()
         _layer_report.material = material
         return _layer_report
@@ -122,8 +117,8 @@ def _create_report(
     _report.profile_cost_report = ProfileCostReport()
     _report.profile_cost_report.reinforced_profile = _reinforced_profile
     _report.profile_cost_report.layer_cost_reports = [
-        _get_layer("Klei", _required_klei),
-        _get_layer("Zand", _required_zand),
+        _get_layer("Klei"),
+        _get_layer("Zand"),
     ]
     return _report
 


### PR DESCRIPTION
## Issue addressed
Solves #168

## Code of conduct
- [x] I HAVE NOT added sensitive or compromised (test) data to the repository.
- [x] I HAVE NOT added vulnerabilities to the repository.
- [x] I HAVE discussed my solution with (other) members of the KOSWAT team.

## What has been done?
Remove unused `SurroundingsInfrastructure` attribute containing `list[PointSurrounding]` from the classes `InfrastructureLocationCosts` and `InfrastructureLocationProfileCostReport` to reduce the object size to be rendered during debugging.

### Checklist
- [x] Tests are either added or updated.
- [x] Branch is up to date with `master`.
- [x] Updated documentation if needed.

## Additional Notes (optional)
Has no significant impact on operational performance.
