### PR TITLE
Fix/224 ordering strategy not as expected

### DIFF
--- a/docs/reference/koswat_strategies.md
+++ b/docs/reference/koswat_strategies.md
@@ -31,15 +31,17 @@ This strategy is the first and default of all defined strategies. Its criteria i
 4. [Clustering](#reinforcement-clustering) to the resulting groupings from the previous step.
 
 #### Reinforcement order
-The predefined (hardcoded) reinforcement's order, from least to most restrictive, is as follows:
+The reinforcements are ordered based on increasing cost (including surtax) and decreasing width.
+Reinforcements that are more expensive but are wider or have equal width are skipped (order `-1`).
+The `CofferDamReinforcementProfile` will never be skipped and is always the last reinforcement that is applied in case no other reinforcement fits the surroundings.
 
-| Priority index | Reinforcement type |
-| ---- | ---- |
-| 0 | `SoilReinforcementProfile` |
-| 1 | `VPSReinforcementProfile` |
-| 2 | `PipingWallReinforcementProfile` |
-| 3 | `StabilityWallReinforcementProfile` |
-| 4 | `CofferDamReinforcementProfile` |
+| Reinforcement type | Profile width | Cost with surtax | Order |
+| ---- | ---- | ---- | ---- |
+| `SoilReinforcementProfile` | 10 | 100 | 0 |
+| `VPSReinforcementProfile` | 20 | 200 | -1 |
+| `PipingWallReinforcementProfile` | 10 | 300 | -1 |
+| `StabilityWallReinforcementProfile` | 5 | 400 | 1 |
+| `CofferDamReinforcementProfile` | 0 | 500 | 2 |
 
 #### Reinforcement grouping
 

--- a/docs/reference/koswat_strategies.md
+++ b/docs/reference/koswat_strategies.md
@@ -35,7 +35,7 @@ The reinforcements are ordered based on increasing cost (including surtax) and d
 Reinforcements that are more expensive but are wider or have equal width are skipped (order `-1`).
 The `CofferDamReinforcementProfile` will never be skipped and is always the last reinforcement that is applied in case no other reinforcement fits the surroundings.
 
-| Reinforcement type | Profile width | Cost with surtax | Order |
+| Reinforcement type | Profile width | Cost with surtax | Index |
 | ---- | ---- | ---- | ---- |
 | `SoilReinforcementProfile` | 10 | 100 | 0 |
 | `VPSReinforcementProfile` | 20 | 200 | -1 |

--- a/docs/reference/koswat_surroundings.md
+++ b/docs/reference/koswat_surroundings.md
@@ -34,7 +34,7 @@ Their headers are divided in the following columns:
 
 ## Obstacles
 
-An obstacle usually represents a building, because they cannot be removed they become a constraint to the possible reinforcements that can be applied at a given location. For instance, if a dike's reinforcement will become 5 meters wider, but within that distance there are obstacles, said reinforcement will be discarded as a possible option at that location.
+An obstacle usually represents a building. Because they cannot be removed they become a constraint to the possible reinforcements that can be applied at a given location. For instance, if a dike's reinforcement will become 5 meters wider, but within that distance there are obstacles, said reinforcement will be discarded as a possible option at that location.
 The distance from the reference point of the dike to the closes point of the obstacle is given.
 
 The values in the columns `afst_{x}m` are either `1` or `0` and are simply interpreted as having a surrounding or not. Thus ignoring other characteristics of the surrounding and just focusing on its presence.

--- a/koswat/cost_report/summary/koswat_summary_location_matrix_builder.py
+++ b/koswat/cost_report/summary/koswat_summary_location_matrix_builder.py
@@ -86,6 +86,7 @@ class KoswatSummaryLocationMatrixBuilder(BuilderProtocol):
             return StrategyReinforcementInput(
                 reinforcement_type=reinforcement_cost.reinforcement_type,
                 base_costs=reinforcement_cost.base_costs,
+                base_costs_with_surtax=reinforcement_cost.base_costs,
                 ground_level_surface=_reinforcement.new_ground_level_surface,
             )
 

--- a/koswat/strategies/order_strategy/order_strategy.py
+++ b/koswat/strategies/order_strategy/order_strategy.py
@@ -91,18 +91,17 @@ class OrderStrategy(StrategyProtocol):
             reverse=True,
         )
 
+        # Remove the reinforcements that are more expensive and less or equally restrictive than 1 of the others
         def check_reinforcement(
             pair: tuple[StrategyReinforcementInput, StrategyReinforcementInput],
         ) -> StrategyReinforcementInput | None:
             if (
-                pair[0].ground_level_surface >= pair[1].ground_level_surface
-                and pair[0].base_costs > pair[1].base_costs
+                pair[0].base_costs > pair[1].base_costs
+                and pair[0].ground_level_surface >= pair[1].ground_level_surface
             ):
                 return pair[0]
             return None
 
-        # Remove the reinforcements that are more expensive and less or equally restrictive than 1 of the others
-        # (the last is always kept)
         _pairs = product(_sorted, _sorted + _last)
         _to_remove = set(
             filter(lambda x: x is not None, map(check_reinforcement, _pairs))

--- a/koswat/strategies/order_strategy/order_strategy.py
+++ b/koswat/strategies/order_strategy/order_strategy.py
@@ -101,7 +101,7 @@ class OrderStrategy(StrategyProtocol):
             )
 
         for _pair in product(_sorted, _sorted + _last):
-            if remove_reinforcement(_pair):
+            if remove_reinforcement(_pair) and _pair[0] in _sorted:
                 _sorted.remove(_pair[0])
 
         return [x.reinforcement_type for x in _sorted + _last]

--- a/koswat/strategies/order_strategy/order_strategy.py
+++ b/koswat/strategies/order_strategy/order_strategy.py
@@ -92,22 +92,17 @@ class OrderStrategy(StrategyProtocol):
         )
 
         # Remove the reinforcements that are more expensive and less or equally restrictive than 1 of the others
-        def check_reinforcement(
+        def remove_reinforcement(
             pair: tuple[StrategyReinforcementInput, StrategyReinforcementInput],
-        ) -> StrategyReinforcementInput | None:
-            if (
+        ) -> bool:
+            return (
                 pair[0].base_costs > pair[1].base_costs
                 and pair[0].ground_level_surface >= pair[1].ground_level_surface
-            ):
-                return pair[0]
-            return None
+            )
 
-        _pairs = product(_sorted, _sorted + _last)
-        _to_remove = set(
-            filter(lambda x: x is not None, map(check_reinforcement, _pairs))
-        )
-        for _reinforcement in _to_remove:
-            _sorted.remove(_reinforcement)
+        for _pair in product(_sorted, _sorted + _last):
+            if remove_reinforcement(_pair):
+                _sorted.remove(_pair[0])
 
         return [x.reinforcement_type for x in _sorted + _last]
 

--- a/koswat/strategies/order_strategy/order_strategy.py
+++ b/koswat/strategies/order_strategy/order_strategy.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from itertools import pairwise, product
+from itertools import product
 
 from koswat.dike_reinforcements.reinforcement_profile import (
     CofferdamReinforcementProfile,
@@ -87,7 +87,7 @@ class OrderStrategy(StrategyProtocol):
         _unsorted, _last = split_reinforcements()
         _sorted = sorted(
             _unsorted,
-            key=lambda x: (x.ground_level_surface, x.base_costs),
+            key=lambda x: (x.ground_level_surface, x.base_costs_with_surtax),
             reverse=True,
         )
 
@@ -96,7 +96,7 @@ class OrderStrategy(StrategyProtocol):
             pair: tuple[StrategyReinforcementInput, StrategyReinforcementInput],
         ) -> bool:
             return (
-                pair[0].base_costs > pair[1].base_costs
+                pair[0].base_costs_with_surtax > pair[1].base_costs_with_surtax
                 and pair[0].ground_level_surface >= pair[1].ground_level_surface
             )
 

--- a/koswat/strategies/strategy_reinforcement_input.py
+++ b/koswat/strategies/strategy_reinforcement_input.py
@@ -9,4 +9,5 @@ from koswat.dike_reinforcements.reinforcement_profile.reinforcement_profile_prot
 class StrategyReinforcementInput:
     reinforcement_type: type[ReinforcementProfileProtocol]
     base_costs: float = 0.0
+    base_costs_with_surtax: float = 0.0
     ground_level_surface: float = 0.0

--- a/koswat/strategies/strategy_reinforcement_input.py
+++ b/koswat/strategies/strategy_reinforcement_input.py
@@ -10,3 +10,6 @@ class StrategyReinforcementInput:
     reinforcement_type: type[ReinforcementProfileProtocol]
     base_costs: float = 0.0
     ground_level_surface: float = 0.0
+
+    def __hash__(self) -> int:
+        return hash(self.reinforcement_type)

--- a/koswat/strategies/strategy_reinforcement_input.py
+++ b/koswat/strategies/strategy_reinforcement_input.py
@@ -10,6 +10,3 @@ class StrategyReinforcementInput:
     reinforcement_type: type[ReinforcementProfileProtocol]
     base_costs: float = 0.0
     ground_level_surface: float = 0.0
-
-    def __hash__(self) -> int:
-        return hash(self.reinforcement_type)

--- a/koswat/strategies/strategy_reinforcement_type_costs.py
+++ b/koswat/strategies/strategy_reinforcement_type_costs.py
@@ -9,7 +9,6 @@ from koswat.dike_reinforcements.reinforcement_profile.reinforcement_profile_prot
 class StrategyReinforcementTypeCosts:
     reinforcement_type: type[ReinforcementProfileProtocol]
     base_costs: float = 0.0
-    # Not needed yet
     base_costs_with_surtax: float = 0.0
     infrastructure_costs: float = 0.0
     infrastructure_costs_with_surtax: float = 0.0

--- a/tests/strategies/conftest.py
+++ b/tests/strategies/conftest.py
@@ -45,6 +45,7 @@ def _get_example_strategy_input() -> Iterator[StrategyInput]:
         StrategyReinforcementTypeCosts(
             reinforcement_type=_reinforcement,
             base_costs=(10**_idx) * 42.0,
+            base_costs_with_surtax=(10**_idx) * 42.0 * 2,
             infrastructure_costs=(10 ** (len(_reinforcement_type_default_order) - 1))
             * 42.0
             if _idx in [0, 1, 3]
@@ -69,6 +70,7 @@ def _get_example_strategy_input() -> Iterator[StrategyInput]:
         StrategyReinforcementInput(
             reinforcement_type=_rtc.reinforcement_type,
             base_costs=_rtc.base_costs,
+            base_costs_with_surtax=_rtc.base_costs_with_surtax,
             ground_level_surface=10.0 * (len(_reinforcement_type_default_order) - _idx),
         )
         for _idx, _rtc in enumerate(_levels_data)

--- a/tests/strategies/infra_priority_stratregy/test_infra_priority_strategy.py
+++ b/tests/strategies/infra_priority_stratregy/test_infra_priority_strategy.py
@@ -170,7 +170,9 @@ class TestInfraPriorityStrategy:
             point_surrounding=None,
             strategy_reinforcement_type_costs=[
                 StrategyReinforcementTypeCosts(
-                    SoilReinforcementProfile, base_costs=42, infrastructure_costs=420000
+                    SoilReinforcementProfile,
+                    base_costs=42,
+                    infrastructure_costs=420000,
                 ),
                 StrategyReinforcementTypeCosts(
                     PipingWallReinforcementProfile,
@@ -191,7 +193,9 @@ class TestInfraPriorityStrategy:
                 ),
                 # Cheapest of all, but only present at one location.
                 StrategyReinforcementTypeCosts(
-                    CofferdamReinforcementProfile, base_costs=42, infrastructure_costs=0
+                    CofferdamReinforcementProfile,
+                    base_costs=42,
+                    infrastructure_costs=0,
                 ),
             ],
         )

--- a/tests/strategies/order_strategy/test_order_strategy.py
+++ b/tests/strategies/order_strategy/test_order_strategy.py
@@ -75,7 +75,7 @@ class TestOrderStrategy:
         # Increase the cost of the reinforcement at the given index
         # to become more expensive than the next (more restrictive) reinforcement
         # and will be filtered out.
-        example_strategy_input.strategy_reinforcements[idx].base_costs *= 20
+        example_strategy_input.strategy_reinforcements[idx].base_costs_with_surtax *= 20
         _expected_result = deepcopy(self._default_reinforcements)
         _expected_result.remove(self._default_reinforcements[idx])
 

--- a/tests/strategies/order_strategy/test_order_strategy.py
+++ b/tests/strategies/order_strategy/test_order_strategy.py
@@ -119,6 +119,38 @@ class TestOrderStrategy:
         assert _reinforcements == _expected_result
         assert _reinforcements[-1] == CofferdamReinforcementProfile
 
+    def test_get_strategy_order_filters_two_consecutive_reinforcements(
+        self, example_strategy_input: StrategyInput
+    ):
+        # 1. Define test data.
+        # Related to #224
+        # 2nd reinforcement is more expensive and less restrictive than the 1st and should be filtered out
+        example_strategy_input.strategy_reinforcements[1].ground_level_surface = (
+            example_strategy_input.strategy_reinforcements[0].ground_level_surface * 2
+        )
+        # 3rd reinforcement is more expensive than and equally restrictive as the 1st and should be filtered out
+        example_strategy_input.strategy_reinforcements[
+            2
+        ].ground_level_surface = example_strategy_input.strategy_reinforcements[
+            0
+        ].ground_level_surface
+        _expected_result = deepcopy(self._default_reinforcements)
+        _expected_result = [
+            SoilReinforcementProfile,
+            StabilityWallReinforcementProfile,
+            CofferdamReinforcementProfile,
+        ]
+
+        _strategy = OrderStrategy()
+
+        # 2. Run test.
+        _reinforcements = _strategy.get_strategy_order_for_reinforcements(
+            example_strategy_input.strategy_reinforcements
+        )
+
+        # 3. Verify expectations
+        assert _reinforcements == _expected_result
+
     def test_get_strategy_reinforcements_given_example(
         self, example_strategy_input: StrategyInput
     ):


### PR DESCRIPTION
## Issue addressed
Solves #224 

## Code of conduct
- [x] I HAVE NOT added sensitive or compromised (test) data to the repository.
- [x] I HAVE NOT added vulnerabilities to the repository.
- [x] I HAVE discussed my solution with (other) members of the KOSWAT team.

## What has been done?
Instead of comparing pairwise which reinforcements to keep, create a product of all reinforcements and check which to remove.

### Checklist
- [x] Tests are either added or updated.
- [x] Branch is up to date with `master`.
- [x] Updated documentation if needed.

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
