### PR TITLE
chore: switch to base_costs_with_surtax

### DIFF
--- a/koswat/cost_report/summary/koswat_summary_location_matrix_builder.py
+++ b/koswat/cost_report/summary/koswat_summary_location_matrix_builder.py
@@ -85,7 +85,8 @@ class KoswatSummaryLocationMatrixBuilder(BuilderProtocol):
                 )
             return StrategyReinforcementInput(
                 reinforcement_type=reinforcement_cost.reinforcement_type,
-                base_costs=reinforcement_cost.base_costs,
+                base_costs=reinforcement_cost.base_cost,
+                base_costs_with_surtax=reinforcement_cost.base_costs,
                 ground_level_surface=_reinforcement.new_ground_level_surface,
             )
 

--- a/koswat/cost_report/summary/koswat_summary_location_matrix_builder.py
+++ b/koswat/cost_report/summary/koswat_summary_location_matrix_builder.py
@@ -85,7 +85,7 @@ class KoswatSummaryLocationMatrixBuilder(BuilderProtocol):
                 )
             return StrategyReinforcementInput(
                 reinforcement_type=reinforcement_cost.reinforcement_type,
-                base_costs=reinforcement_cost.base_cost,
+                base_costs=reinforcement_cost.base_costs,
                 base_costs_with_surtax=reinforcement_cost.base_costs,
                 ground_level_surface=_reinforcement.new_ground_level_surface,
             )

--- a/koswat/strategies/order_strategy/order_strategy.py
+++ b/koswat/strategies/order_strategy/order_strategy.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from itertools import pairwise, product
+from itertools import product
 
 from koswat.dike_reinforcements.reinforcement_profile import (
     CofferdamReinforcementProfile,
@@ -87,7 +87,7 @@ class OrderStrategy(StrategyProtocol):
         _unsorted, _last = split_reinforcements()
         _sorted = sorted(
             _unsorted,
-            key=lambda x: (x.ground_level_surface, x.base_costs),
+            key=lambda x: (x.ground_level_surface, x.base_costs_with_surtax),
             reverse=True,
         )
 
@@ -96,7 +96,7 @@ class OrderStrategy(StrategyProtocol):
             pair: tuple[StrategyReinforcementInput, StrategyReinforcementInput],
         ) -> bool:
             return (
-                pair[0].base_costs > pair[1].base_costs
+                pair[0].base_costs_with_surtax > pair[1].base_costs_with_surtax
                 and pair[0].ground_level_surface >= pair[1].ground_level_surface
             )
 

--- a/koswat/strategies/strategy_reinforcement_input.py
+++ b/koswat/strategies/strategy_reinforcement_input.py
@@ -9,4 +9,5 @@ from koswat.dike_reinforcements.reinforcement_profile.reinforcement_profile_prot
 class StrategyReinforcementInput:
     reinforcement_type: type[ReinforcementProfileProtocol]
     base_costs: float = 0.0
+    base_costs_with_surtax: float = 0.0
     ground_level_surface: float = 0.0

--- a/koswat/strategies/strategy_reinforcement_type_costs.py
+++ b/koswat/strategies/strategy_reinforcement_type_costs.py
@@ -9,7 +9,6 @@ from koswat.dike_reinforcements.reinforcement_profile.reinforcement_profile_prot
 class StrategyReinforcementTypeCosts:
     reinforcement_type: type[ReinforcementProfileProtocol]
     base_costs: float = 0.0
-    # Not needed yet
     base_costs_with_surtax: float = 0.0
     infrastructure_costs: float = 0.0
     infrastructure_costs_with_surtax: float = 0.0

--- a/tests/strategies/conftest.py
+++ b/tests/strategies/conftest.py
@@ -45,6 +45,7 @@ def _get_example_strategy_input() -> Iterator[StrategyInput]:
         StrategyReinforcementTypeCosts(
             reinforcement_type=_reinforcement,
             base_costs=(10**_idx) * 42.0,
+            base_costs_with_surtax=(10**_idx) * 42.0 * 2,
             infrastructure_costs=(10 ** (len(_reinforcement_type_default_order) - 1))
             * 42.0
             if _idx in [0, 1, 3]
@@ -69,6 +70,7 @@ def _get_example_strategy_input() -> Iterator[StrategyInput]:
         StrategyReinforcementInput(
             reinforcement_type=_rtc.reinforcement_type,
             base_costs=_rtc.base_costs,
+            base_costs_with_surtax=_rtc.base_costs_with_surtax,
             ground_level_surface=10.0 * (len(_reinforcement_type_default_order) - _idx),
         )
         for _idx, _rtc in enumerate(_levels_data)

--- a/tests/strategies/infra_priority_stratregy/test_infra_priority_strategy.py
+++ b/tests/strategies/infra_priority_stratregy/test_infra_priority_strategy.py
@@ -170,7 +170,9 @@ class TestInfraPriorityStrategy:
             point_surrounding=None,
             strategy_reinforcement_type_costs=[
                 StrategyReinforcementTypeCosts(
-                    SoilReinforcementProfile, base_costs=42, infrastructure_costs=420000
+                    SoilReinforcementProfile,
+                    base_costs=42,
+                    infrastructure_costs=420000,
                 ),
                 StrategyReinforcementTypeCosts(
                     PipingWallReinforcementProfile,
@@ -191,7 +193,9 @@ class TestInfraPriorityStrategy:
                 ),
                 # Cheapest of all, but only present at one location.
                 StrategyReinforcementTypeCosts(
-                    CofferdamReinforcementProfile, base_costs=42, infrastructure_costs=0
+                    CofferdamReinforcementProfile,
+                    base_costs=42,
+                    infrastructure_costs=0,
                 ),
             ],
         )

--- a/tests/strategies/order_strategy/test_order_strategy.py
+++ b/tests/strategies/order_strategy/test_order_strategy.py
@@ -75,7 +75,7 @@ class TestOrderStrategy:
         # Increase the cost of the reinforcement at the given index
         # to become more expensive than the next (more restrictive) reinforcement
         # and will be filtered out.
-        example_strategy_input.strategy_reinforcements[idx].base_costs *= 20
+        example_strategy_input.strategy_reinforcements[idx].base_costs_with_surtax *= 20
         _expected_result = deepcopy(self._default_reinforcements)
         _expected_result.remove(self._default_reinforcements[idx])
 


### PR DESCRIPTION
## Issue addressed
Solves #224

## Code of conduct
- [x] I HAVE NOT added sensitive or compromised (test) data to the repository.
- [x] I HAVE NOT added vulnerabilities to the repository.
- [x] I HAVE discussed my solution with (other) members of the KOSWAT team.

## What has been done?
Add `base_costs_with_surtax` to `StrategyReinforcementInput` and consider that value to determine the reinforcement order in `OrderStrategy`.

### Checklist
- [x] Tests are either added or updated.
- [ ] Branch is up to date with `master`.
- [x] Updated documentation if needed.

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
