### PR TITLE
chore: add random suffix to temp foldername

### DIFF
--- a/tests/configuration/io/test_surroundings_wrapper_collection_importer.py
+++ b/tests/configuration/io/test_surroundings_wrapper_collection_importer.py
@@ -70,6 +70,7 @@ class TestSurroundingsWrapperCollectionImporter:
     ) -> Path:
         # Create a copy of the directory in a temporary location
         _case_name = get_fixturerequest_case_name(request)
+        # Add randomizer to prevent name clashes
         _case_name = (
             _case_name
             + "_"


### PR DESCRIPTION
## Issue addressed
Solves #312

## What has been done?
Add random suffix to avoid using identical results dir, which causes issues.

### Checklist
- [ ] I HAVE discussed my solution with (other) members of the KOSWAT team.
- [ ] Tests are either added or updated.
- [ ] Branch is up to date with `master`.
- [ ] Updated documentation if needed.

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
